### PR TITLE
Fix bug: add register operand field to j-type instruction

### DIFF
--- a/assembler/examples/jal-test.asm
+++ b/assembler/examples/jal-test.asm
@@ -1,0 +1,19 @@
+# Add some comments to describe the program
+
+# the TEXT Section
+    .text
+    .org    0
+main:
+
+    li a0, 21      # A sample instruction
+    jal x3, L1     # jump to L1
+    addi a0, 2     # This instruction should be skipped
+
+L1:
+    ecall 1        # should print 21
+
+exit:
+    ecall 3
+
+    .data
+    .org    0x100

--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -766,10 +766,10 @@
                      exit(1);
                  }
                  int offset3To1 = (offset >> 1) & 0x7;
-                 int offset15To10 = (offset >> 10) & 0x3F;
+                 int offset9To4 = (offset >> 4) & 0x3F;
                  int f = (cmpIgnoreCase(inst->mnemonic, "jal") == 0) ? 1 : 0;
                  machineWord |= (f & 0x1) << 15;
-                 machineWord |= ((offset15To10) << 9);
+                 machineWord |= ((offset9To4) << 9);
                  machineWord |= ((rd & 0x7) << 6);
                  machineWord |= ((offset3To1) << 3);
                  machineWord |= (inst->opcode & 0xF);


### PR DESCRIPTION
# PR Description

This PR fixes an issue where assembling a file containing the `jal rd, label` instruction incorrectly results in an "Undefined label" error.

# Changes Made

- Included a register operand field in `pass2()` for `INST_J` instructions.
- Added an error message to account for the absence of a register operand.
- Split the `offset` immediate into `offset3To1` and `offset9To4`, ensuring correct placement in `machineWord`.
- Added `jal-test.asm` file in the `examples` folder to test the new modifications.

# Previous vs. Fixed Behavior  

### Previous Behavior:
The assembler fails with the following error:  
```
Error on line 9: Undefined label 'x3,'
```

### Fixed Behavior:
The assembler now executes successfully, generating the following output:  
```
Listing file generated: examples/jal-test.lst
Binary file generated: examples/jal-test.bin
```

# Linked Issue

Closes #1 
