### PR TITLE
Bug fix <auipc f (bit 15)>

### DIFF
--- a/assembler/examples/auipc_testing.asm
+++ b/assembler/examples/auipc_testing.asm
@@ -1,0 +1,11 @@
+.org 0x0000
+.text
+start:
+    lui   a0, 0x10000
+    auipc a1, 0x20000
+    mv    a0, a1
+    jal   a0, label
+
+label:
+    ecall 1
+    ecall 3


### PR DESCRIPTION
## 🐛 Bug Description  
The assembler incorrectly considers both `lui` and `auipc` as `lui` because it does not differentiate between them based on the most significant bit (`f`).

- If `f = 0`, it should be `lui`.  
- If `f = 1`, it should be `auipc`.  

##  Steps to Reproduce  
Use the following test case:  

```assembly
.org 0x0000
.text
start:
    lui   a0, 0x10000
    auipc a1, 0x20000
    mv    a0, a1
    jal   a0, label

label:
    ecall 1
    ecall 3
```
## Expected Behavior
```assembly
lui   a0, 0x30   # Correct interpretation of LUI
0x0000: 0186
auipc a1, 0x38   # Correct interpretation of AUIPC
0x0002: 81C6

```
## Actual Behavior
```assembly
lui   a0, 0x30   # LUI is correct
0x0000: 0186
lui   a1, 0x38   # Incorrect-Should be AUIPC
0x0002: 01C6

