### PR TITLE
Bug fix <j type instructions not jumping correctly to the label and infinite calls>

### DIFF
--- a/assembler/examples/Testcase7 (1).asm
+++ b/assembler/examples/Testcase7 (1).asm
@@ -1,0 +1,17 @@
+.text
+.org    0
+main:
+    li a0, 5
+    li t0, 1
+    sra a0, t0
+    li a0, 3
+    sltui a0, 2
+    jal x3, func
+func:
+    xori a0, 6
+    ecall 1
+    jal x3, exit
+
+exit:
+    ecall 3
+


### PR DESCRIPTION
### Fix: Correctly jumping to the label of the jal AND correctly encoding J-type especially offset handeling
"I continued on the edit that Adham El-Rouby did to consider the j-type registers. #2"

### Bug Description
There is an infinite call that happens in the simulator due to the incorrect jumping to the label of the Jal which indeed affects the encoding of preceding instruction, eventually leading to incorrect output.

### Steps to Reproduce
Use the following test case:
```assembly
.text
.org 0
main:
li a0, 5
li t0, 1
sra a0, t0
li a0, 3
sltui a0, 2
jal x3, func
func:
xori a0, 6
ecall 1
jal x3, exit

exit:
ecall 3
```
### Expected output from the simulator:
The hexa encoding is:
B9 0B 39 02 98 81 B9 07 91 05 CD 80 B1 0D 47 00 CD 80 C7 00

![wwwww](https://github.com/user-attachments/assets/093ecfda-9360-4abd-826e-bb1603e01123)
### Actual output from the simulator:
The hexa encoding is
B9 0B 39 02 98 81 B9 07 91 05 CD 80 B1 0D 17 00 CD 80 37 00

![xxxx](https://github.com/user-attachments/assets/99795c5b-7762-4f2b-9ba6-1809b8fdbcaf)


