### PR TITLE
Fix bug: jr operands encoding and add test case

### DIFF
--- a/assembler/examples/JRtestcase.asm
+++ b/assembler/examples/JRtestcase.asm
@@ -1,0 +1,20 @@
+# Function Calls
+
+    .text
+    .org    0
+main:
+
+li a0, 5
+li t0, 1
+sra a0, t0
+li t0, 118
+sltu a0, t0
+jal ra, func
+ecall 1
+
+ecall 3
+
+
+func:
+xori a0, 6
+jr ra


### PR DESCRIPTION
This is the fix for the issue: [Fixing encoding of the jr instruction's register]. Issue #8
The bug was that the jr's operand was encoded in the destination register's field and not the source which defies its encoding guidelines.
I fixed it by storing the operand's encoding in reg2 instead of reg1.
I added the testcase JRtestcase.asm to verify it works.