### PR TITLE
Fix offset calculation for two-register branch

### DIFF
--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -169,7 +169,7 @@
      {"srai",  INST_I, 1, 3, 0},
      {"ori",   INST_I, 1, 4, 0},
      {"andi",  INST_I, 1, 5, 0},
-     {"xor",   INST_R, 0, 6, 0},
+     {"xori",   INST_I, 1, 6, 0},
      {"li",    INST_I, 1, 7, 0},
      {"beq",   INST_B, 2, 0, 0},
      {"bne",   INST_B, 2, 1, 0},
@@ -649,7 +649,7 @@
                          fprintf(stderr, "Error on line %d: Undefined label '%s'\n", line->lineNo, token);
                          exit(1);
                      }
-                     offset = (sym->address - (line->address + 2)) >> 1;
+                     offset = (sym->address - (line->address)) >> 1;  //Fix offset calculations 
                      if(offset < -8 || offset > 7) {
                          fprintf(stderr, "Error on line %d: Branch offset out of range\n", line->lineNo);
                          exit(1);


### PR DESCRIPTION
Previously, I corrected the offset calculation for the one-register branch. However, I have noticed the same issue in the two-register branch, where an unnecessary +2 was added to the offset. In addition, I have added the correct opcode for XORI.

## Steps to Reproduce:
-Assemble the following test case:
```assembly
.org 0x0000
.text
start:
    li   a0, 11
    li   a1, 9
    beq  a0, a1, branch_equal
branch_notequal:
    li   t0, 2
    addi a0, -1
branch_equal:
    li   t0, 1
    bne  a0, a1, branch_notequal
    ecall 3
```
## Expected Output:
```assembly
li a0, 11
0x0000: 17B9
li a1, 9
0x0002: 13F9
beq a0, a1, 6
0x0004: 3F82
li t0, 2
0x0006: 0439
addi a0, -1
0x0008: FF81
li t0, 1
0x000A: 0239
bne a0, a1, -6
0x000C: DF8A
li t0, 2
0x0006: 0439
addi a0, -1
0x0008: FF81
li t0, 1
0x000A: 0239
bne a0, a1, -6
0x000C: DF8A
ecall 3
0x000E: 00C7
```
## Actual Output:
```assembly
li a0, 11
0x0000: 17B9
li a1, 9
0x0002: 13F9
beq a0, a1, 4
0x0004: 2F82
li t0, 2
0x0006: 0439
addi a0, -1
0x0008: FF81
li t0, 1
0x000A: 0239
bne a0, a1, -8
0x000C: CF8A
beq a0, a1, 4             # It doesn't  jump to the intended destination but instead returns to the instruction right before it. 
0x0004: 2F82
li t0, 2
0x0006: 0439
addi a0, -1
0x0008: FF81
li t0, 1
0x000A: 0239
bne a0, a1, -8
0x000C: CF8A
ecall 3
0x000E: 00C7

