### PR TITLE
fixed offset for jump since it is 10 bit

### DIFF
--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -761,7 +761,7 @@
                  int currPC = line->address;
                  int targetPC = sym->address;
                  int offset = (targetPC - currPC);
-                 if(offset < -128 || offset > 127) {
+                 if(offset < -512 || offset > 511) {
                      fprintf(stderr, "Error on line %d: Jump offset out of range\n", line->lineNo);
                      exit(1);
                  }


### PR DESCRIPTION
Changed the outlines for the offeset to have range from -512 to 511 since the offset is 10 bits, so the previous range of -128 to 127 is false 