### PR TITLE
Fix bug: Not supporting symbolic addresses as immediates in LUI instructions

### DIFF
--- a/assembler/examples/LUI-test.asm
+++ b/assembler/examples/LUI-test.asm
@@ -1,0 +1,19 @@
+.text
+.org 0
+main:
+    lui a0, %hi(w)
+    addi a0, %lo(w) # Load address 0x100 into a0
+    ecall 1
+    lw t1, 0(a0) # Load word from memory address in a0 into t1
+    lb t0, 2(a0) # Load byte from memory address a0 + 2 into t0
+    mv a0, t1
+    ecall 1
+    ecall 3
+    sw t1, 4(a0) # Store word t1 into memory at a0 + 4
+    sb t0, 6(a0) # Store byte t0 into memory at a0 + 6
+    ecall 3 # Terminate program
+
+.data
+.org 0x100
+    w: .word 12
+    b: .byte 0xAA

--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -229,35 +229,44 @@
  }
 
  // Parse an immediate value. Supports decimal, octal, hex, binary, %hi(...) and %lo(...).
- int parseImmediate(const char *token) {
-     if(strncmp(token, "%hi(", 4)==0) {
+int parseImmediate(const char *token) {
+     Symbol* token_symbol = findSymbol(token);
+     if(token_symbol) {
+         return token_symbol->address;  // Directly return symbol address if found
+     }
+
+     if(strncmp(token, "%hi(", 4) == 0) {
          const char *p = token + 4;
-         char numberStr[64];
+         char innerToken[64];
          int i = 0;
          while(*p && *p != ')') {
-             numberStr[i++] = *p++;
+             innerToken[i++] = *p++;
          }
-         numberStr[i] = '\0';
-         int value = (int)strtol(numberStr, NULL, 0);
+         innerToken[i] = '\0';
+
+         // Check if inner token is a symbol
+         Symbol* inner_symbol = findSymbol(innerToken);
+         int value = inner_symbol ? inner_symbol->address : (int)strtol(innerToken, NULL, 0);
+
          return value >> 7;
      }
-     if(strncmp(token, "%lo(", 4)==0) {
+
+     if(strncmp(token, "%lo(", 4) == 0) {
          const char *p = token + 4;
-         char numberStr[64];
+         char innerToken[64];
          int i = 0;
          while(*p && *p != ')') {
-             numberStr[i++] = *p++;
+             innerToken[i++] = *p++;
          }
-         numberStr[i] = '\0';
-         int value = (int)strtol(numberStr, NULL, 0);
+         innerToken[i] = '\0';
+
+         // Check if inner token is a symbol
+         Symbol* inner_symbol = findSymbol(innerToken);
+         int value = inner_symbol ? inner_symbol->address : (int)strtol(innerToken, NULL, 0);
+
          return value & 0x7F;
      }
-     // Support binary constants with "0b" or "0B" prefix.
-     if(token[0]=='0' && (token[1]=='b' || token[1]=='B'))
-         return (int)strtol(token+2, NULL, 2);
-     return (int)strtol(token, NULL, 0);
  }
-
  // -----------------------
  // Source Line Structures and Parsing
  // -----------------------


### PR DESCRIPTION
The issue stemmed from not properly treating symbolic addresses as valid immediate values when parsing LUI instructions. The solution was simple: first, check whether the immediate is a valid symbol. If it is, return its address. Otherwise, check if the immediate has a prefix (e.g. 'lo' or 'hi'). If it does, verify whether the actual immediate after the prefix is a valid symbol, and if so, return its address.

The added test case is named 'lui-test'. Before this issue was fixed, LUI would treat symbolic immediates as zeros instead of their actual addresses.