### PR TITLE
fixed checking registers with jr and jalr 

### DIFF
--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -761,7 +761,7 @@
                  int currPC = line->address;
                  int targetPC = sym->address;
                  int offset = (targetPC - currPC);
-                 if(offset < -128 || offset > 127) {
+                 if(offset < -512 || offset > 511) {
                      fprintf(stderr, "Error on line %d: Jump offset out of range\n", line->lineNo);
                      exit(1);
                  }

--- a/assembler/z16asm.c
+++ b/assembler/z16asm.c
@@ -543,16 +543,20 @@
                  int reg2;
                  token = strtok(NULL, ", \t");
                  if(!token) {
-                     // For jr and jalr, if second operand is missing, set reg2 = 0.
-                     if(cmpIgnoreCase(inst->mnemonic, "jr") == 0 ||
-                        cmpIgnoreCase(inst->mnemonic, "jalr") == 0) {
-                         reg2 = 0;
+                    // Only one operand given, check if it's "jr" or "jalr"
+                    if(cmpIgnoreCase(inst->mnemonic, "jr") == 0) {
+                         reg2 = reg1;
                      } else {
                          fprintf(stderr, "Error on line %d: Expected second register operand\n", line->lineNo);
                          exit(1);
                      }
                  } else {
-                     reg2 = parseRegister(token);
+                    if(cmpIgnoreCase(inst->mnemonic, "jr") == 0) {
+                        fprintf(stderr, "Error on line %d: Unexpected second operand for 'jr'\n", line->lineNo);
+                        exit(1); 
+                    } else {
+                        reg2 = parseRegister(token);
+                    }
                  }
                  machineWord |= (inst->funct4 & 0xF) << 12;
                  machineWord |= (reg2 & 0x7) << 9;


### PR DESCRIPTION
This change refines the handling of the jr and jalr instructions, addressing issues with missing or unexpected operands.

**Changes:**
- For jr: If no second operand is provided, reg2 is set to reg1 (the jump address is the same as the source register). An error is thrown if a second operand is present.
- For jalr: The second operand is parsed and assigned to reg2, as expected.