### PR TITLE
Fixed constant 64KB binary file size

### DIFF
--- a/assembler/zx16asm.py
+++ b/assembler/zx16asm.py
@@ -1226,21 +1226,27 @@ class ZX16Assembler:
             raise SyntaxError(f"Unknown instruction: {mnemonic}")
     
     def get_binary_output(self) -> bytes:
-        """Get binary output."""
-        # Combine all sections
-        output = bytearray(65536)  # 64KB memory space
-        
-        # Write text section
+        """Get binary output with only the necessary bytes written."""
+        output = bytearray(65536)  # max memory size
+        max_address = 0
+
+        # Write .text section
         text_start = self.section_addresses['.text']
         text_data = self.sections['.text']
         output[text_start:text_start + len(text_data)] = text_data
-        
-        # Write data section
+        if text_data:
+            max_address = max(max_address, text_start + len(text_data))
+
+        # Write .data section
         data_start = self.section_addresses['.data']
         data_data = self.sections['.data']
         output[data_start:data_start + len(data_data)] = data_data
-        
-        return bytes(output)
+        if data_data:
+            max_address = max(max_address, data_start + len(data_data))
+
+        return bytes(output[:max_address])
+
+
     
     def get_intel_hex_output(self) -> str:
         """Get Intel HEX format output."""


### PR DESCRIPTION
Issue #40. Issue where the binary file size is constant at 64KB. fixed by calculating the size of the data and text sections, getting their maximum and using that instead of the 64KB fixed number