### PR TITLE
bug-fix-i-type-immediate-range

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,4 +7,7 @@
     <option name="/Default/Environment/Hierarchy/GeneratedFilesCacheKey/Timestamp/@EntryValue" value="21" type="long" />
     <option name="/Default/Housekeeping/OptionsDialog/SelectedPageId/@EntryValue" value="CppFormatterOtherPage" type="string" />
   </component>
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (z16-fork)" />
+  </component>
 </project>

--- a/.idea/z16.iml
+++ b/.idea/z16.iml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="CPP_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Python" name="Python facet">
+      <configuration sdkName="Python 3.12 (z16-fork)" />
+    </facet>
+  </component>
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Python 3.12 (z16-fork) interpreter library" level="application" />
   </component>
 </module>

--- a/assembler/examples/test_i_type_range.s
+++ b/assembler/examples/test_i_type_range.s
@@ -1,0 +1,6 @@
+.text
+.org 0x0020
+    addi x1, 63      # ✅ valid
+    addi x1, -64     # ✅ valid
+    addi x1, 64      # ❌ should raise error
+    addi x1, -65     # ❌ should raise error

--- a/assembler/zx16asm.py
+++ b/assembler/zx16asm.py
@@ -1059,27 +1059,29 @@ class ZX16Assembler:
             
             encoding = (funct4 << 12) | (rs2 << 9) | (rd << 6) | (func3 << 3) | InstructionFormat.R_TYPE.value
             return encoding
-        
+
         # I-Type instructions
         elif mnemonic in parser.i_type_instructions:
             if len(operands) < 2:
                 raise SyntaxError(f"I-Type instruction {mnemonic} requires 2 operands")
-            
+
             func3 = parser.i_type_instructions[mnemonic]
             rd = operands[0]
             imm = operands[1]
-            
+
             if isinstance(imm, str):
-                raise SyntaxError(f"Unresolved symbol in immediate: {imm}")
-            
-            # Sign extend 7-bit immediate
-            imm = parser.sign_extend(imm, 7)
-            if imm < -64 or imm > 63:
-                raise SyntaxError(f"Immediate out of range: {imm}")
-            
+               raise SyntaxError(f"Unresolved symbol in immediate: {imm}")
+
+            if not isinstance(imm, int):
+                raise SyntaxError(f"Immediate must be an integer or symbol, got {type(imm)}")
+
+            if not -64 <= imm <= 63:
+                raise SyntaxError(f"I-type immediate out of range: {imm}")
+
+         # Encode: imm[6:0] << 9 | rd << 6 | func3 << 3 | opcode
             encoding = ((imm & 0x7F) << 9) | (rd << 6) | (func3 << 3) | InstructionFormat.I_TYPE.value
             return encoding
-        
+
         # Shift instructions (special I-Type)
         elif mnemonic in parser.shift_instructions:
             if len(operands) < 2:


### PR DESCRIPTION
## Summary

Fixes encoding bug in I-type instructions (e.g. `addi`) where immediates beyond the 7-bit signed range [-64, 63] were accepted and incorrectly encoded.

## Changes Made

- Added range check before encoding immediate.
- Removed incorrect use of sign extension during encoding.
- Added test case `examples/test_i_type_range.s` that triggers both valid and invalid cases.

## Fixes

Closes #<issue-number>  ← (if you created a GitHub issue)

## Testing

Tested with:
- `addi x1, 63` → OK
- `addi x1, -64` → OK
- `addi x1, 64` → Error
- `addi x1, -65` → Error

All cases behave as expected.
