### PR TITLE
Add ZC compiler + simulator; fix assembler bugs

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,0 +1,93 @@
+# ZX16 / ZC project — file manifest
+
+Everything generated in this conversation, grouped by purpose.
+
+## Repository layout
+
+```
+.
+├── MANIFEST.md
+├── assembler/   zx16asm.py
+├── simulator/   zx16sim.py
+├── compiler/    zcc.py, codegen.py, codegen_patterns.py
+│   ├── examples/   01_gpio_set.c .. 07_tea.c
+│   └── tests/      test_patterns.py, test_compile.py, test_embedded.py
+└── docs/        README_corrected.md (ISA spec), SPEC.md (ZC language)
+```
+
+This mirrors the upstream `shalan/zx16` layout (assembler/, simulator/, docs/) and
+adds `compiler/` for the ZC toolchain. The suites resolve their own paths, so they
+run from anywhere, e.g. `python3 compiler/tests/test_compile.py`.
+
+## ZX16 ISA (the assembly target)
+
+- **README_corrected.md** — corrected ZX16 ISA specification. Fixes the original
+  repo's LI16 expansion (LUI+ORI, not ADDI), removes the unimplemented LJ pseudo,
+  corrects NOP/NEG, documents that x0 is general-purpose (not hardwired zero),
+  clarifies U-Type/SYS encodings, and notes branches/jumps are PC+2-relative.
+- **zx16asm.py** — the repo assembler with three bug fixes applied (drop-in replacement):
+  1. logical-immediate range (ORI/ANDI/XORI accept full 7-bit field 0..127),
+  2. pseudo-instruction sizing (push/pop/la are 4 bytes — labels after them were
+     misplaced before),
+  3. J-type jump range corrected to -512..+510 bytes. The offset field is imm[9:1]
+     with the sign at bit 9, so only -512..+510 round-trips; the original -1024..+1020
+     check silently miscompiled 511 offsets (e.g. +800 assembled, then executed as -224).
+
+  The three fixes are applied directly in `assembler/zx16asm.py` (a drop-in replacement
+  for the upstream file); no separate patch files are kept.
+
+## ZC language + compiler
+
+- **SPEC.md** — the ZC-embedded language specification. A self-hosting C subset with
+  int/unsigned/char/pointers/arrays/structs, if/else, while + break/continue, full
+  arithmetic+bitwise+unsigned operators, MMIO casts, volatile, asm(), hex literals.
+  Drops for/switch/&&/||/! and the usual big-C items.
+- **zcc.py** — lexer + recursive-descent parser producing a flat AST node table.
+- **codegen.py** — AST -> ZX16 assembly walk: symbol table, type tracking
+  (signed/unsigned, byte/word), lvalue/address generation, structs, pointers,
+  arrays, globals, string pool, putint/putchar intrinsics.
+- **codegen_patterns.py** — the validated codegen pattern library (the emit
+  primitives codegen.py drives): expression eval, control flow, prologue/epilogue,
+  far-calls, far-jumps, the __mul/__div/__mod software runtime.
+
+## Execution / verification infrastructure
+
+- **zx16sim.py** — a ZX16 instruction-set simulator with an MMIO device model
+  (write log + scriptable register reads) so embedded programs are verified by
+  execution, not assumed correct.
+
+## Test suites (all currently green)
+
+- **test_patterns.py** — 11/11 codegen primitives validated by execution.
+- **test_compile.py** — 12/12 end-to-end ZC programs compiled and run.
+- **test_embedded.py** — 5/5 embedded examples verified (incl. MMIO write-log checks).
+
+## Example C programs (compiler/examples/)
+
+- 01_gpio_set.c — GPIO bit set/clear via MMIO register   [verified]
+- 02_poll_status.c — poll status register until READY     [verified]
+- 03_reg_map.c — timer peripheral as a struct register map [verified]
+- 04_checksum.c — XOR checksum over a byte buffer          [verified]
+- 05_ring_buffer.c — FIFO ring buffer with wrap masking    [verified]
+- 06_matmul.c — 3x3 integer matrix multiply               [verified vs reference]
+- 07_tea.c — TEA cipher w/ 32-bit emulation layer  [verified vs reference]
+
+## Resolved: the TEA failure was struct-global under-allocation
+
+07_tea.c was the only program using struct *globals* (v0/v1/sum/k0..k3/delta), and it
+printed wrong output. This was first hypothesized to be an evaluation-order bug (a
+stale left operand), but execution tracing showed the real cause: codegen emitted a
+single `.word` (2 bytes) for every non-array global regardless of type, so each 4-byte
+struct global was under-allocated and overlapped the next one (A.hi aliased B.lo).
+Setting one struct's `.lo` silently clobbered the previous struct's `.hi` -- which
+*looked like* ".lo was read where .hi was needed." Fixed in codegen.py by reserving
+each global's full, word-rounded size. TEA now matches a reference 32-bit TEA exactly
+(0x8394fb95, 0x8da99b8b), and the path to MD5 / integer-FFT is unblocked.
+
+## Status summary
+
+Working: ZX16 assembler (fixed), simulator, ZC compiler (lexer/parser/codegen),
+self-hosting-grade feature set, far-call/far-jump for large programs.
+Verified by execution: 28 test programs + 5 embedded examples + matmul + TEA.
+Not done: the actual self-host (compiler is written in Python, not yet in ZC);
+MD5 and FFT stress tests (now unblocked).

--- a/assembler/zx16asm.py
+++ b/assembler/zx16asm.py
@@ -830,10 +830,15 @@ class ZX16Assembler:
                     else:
                         self.current_address += 4  # Expands to LI16 (LUI + ORI)
                 elif mnemonic in parser.pseudo_instructions:
-                    if mnemonic in ['li16', 'neg']:
+                    # Size must match the actual expansion in
+                    # expand_pseudo_instruction(), or labels after a pseudo
+                    # will be misplaced.
+                    #   li16, la, push, pop, neg  -> 2 instructions (4 bytes)
+                    #   call, ret, inc, dec, not, clr, nop -> 1 instruction (2 bytes)
+                    if mnemonic in ['li16', 'la', 'push', 'pop', 'neg']:
                         self.current_address += 4  # Expands to 2 instructions
                     else:
-                        self.current_address += 2  # Most expand to 1 instruction
+                        self.current_address += 2  # Expands to 1 instruction
                 else:
                     self.current_address += 2  # Regular instruction
                 
@@ -1080,8 +1085,19 @@ class ZX16Assembler:
             if not isinstance(imm, int):
                 raise SyntaxError(f"Immediate must be an integer or symbol, got {type(imm)}")
 
-            if not -64 <= imm <= 63:
-                raise SyntaxError(f"I-type immediate out of range: {imm}")
+            # The imm7 field is 7 bits wide and sign-extended at execution time.
+            # Arithmetic/compare/li immediates are signed: -64..63.
+            # Logical immediates (ORI/ANDI/XORI) are commonly written as unsigned
+            # bit masks, so also accept 0..127; the assembler stores the low 7 bits
+            # either way. This is the range LI16's ORI step relies on.
+            if mnemonic in ('ori', 'andi', 'xori'):
+                if not -64 <= imm <= 127:
+                    raise SyntaxError(
+                        f"{mnemonic.upper()} immediate out of range "
+                        f"(expected -64..127): {imm}")
+            else:
+                if not -64 <= imm <= 63:
+                    raise SyntaxError(f"I-type immediate out of range: {imm}")
 
          # Encode: imm[6:0] << 9 | rd << 6 | func3 << 3 | opcode
             encoding = ((imm & 0x7F) << 9) | (rd << 6) | (func3 << 3) | InstructionFormat.I_TYPE.value
@@ -1183,7 +1199,12 @@ class ZX16Assembler:
                 raise SyntaxError(f"Unresolved symbol in jump target: {target}")
             
             offset = target - (self.current_address + 2)
-            if offset < -1024 or offset > 1020 or offset % 2 != 0:
+            # The J offset is encoded as imm[9:1] (9 bits) with imm[0]=0 and the
+            # sign bit at bit 9, so the round-trip-safe signed range is -512..+510 --
+            # NOT the -1024..+1022 the prose elsewhere claims. The old -1024..1020
+            # check accepted 511 offsets that silently miscompiled (e.g. +800 would
+            # encode and then decode as -224). Keep the check tight to the encoding.
+            if offset < -512 or offset > 510 or offset % 2 != 0:
                 raise SyntaxError(f"Jump offset out of range or not word-aligned: {offset}")
             
             imm_high = (offset >> 4) & 0x3F

--- a/compiler/codegen.py
+++ b/compiler/codegen.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""
+ZC codegen walk: AST (from zcc.Parser) -> ZX16 assembly, via codegen_patterns.
+
+Conventions:
+  - Every rvalue expression evaluates with result in x6.
+  - Every lvalue evaluates its ADDRESS into x6 (gen_addr).
+  - Locals/params live in the frame; globals/strings in labeled memory.
+  - Types are tracked enough to choose signed/unsigned compares & shifts, byte vs
+    word access, and pointer arithmetic scaling.
+"""
+import codegen_patterns as C
+import zcc
+
+WORD = 2
+
+class CodegenError(Exception): pass
+
+class Func:
+    def __init__(self, name):
+        self.name=name
+        self.slots={}      # varname -> (frame_index, type)  (locals + params unified)
+        self.n_locals=0
+        self.param_order=[] # names in order
+
+class Codegen:
+    def __init__(self, parser):
+        self.P=parser
+        self.e=C.Emitter()
+        self.strings=[]      # list of (label, text)
+        self.global_syms={}  # name -> (label, type, arrlen)
+        self.cur=None        # current Func
+        self.func_types={}   # fname -> return type
+
+    # ---------- type helpers ----------
+    def is_unsigned(self, t):
+        return t is not None and t.get('ptr',0)==0 and t['base'] in ('unsigned','uchar')
+    def is_byte(self, t):
+        return t is not None and t.get('ptr',0)==0 and t['base'] in ('char','uchar')
+    def is_ptr(self, t):
+        return t is not None and t.get('ptr',0)>0
+    def elem_type(self, t):
+        # type pointed to / element type
+        return {'base':t['base'],'ptr':t['ptr']-1} if t['ptr']>0 else t
+    def type_size(self,t): return self.P.type_size(t)
+    def elem_size(self, t):
+        # size of what a pointer/array element addresses
+        if t['ptr']>1: return WORD
+        if t['ptr']==1:
+            b=t['base']
+            if b in ('char','uchar'): return 1
+            if b in ('int','unsigned'): return 2
+            if isinstance(b,tuple): return self.P.structs[b[1]]['size']
+            return 2
+        return self.type_size(t)
+
+    # ---------- program ----------
+    def gen_program(self):
+        e=self.e
+        C.crt0(e)
+        C.runtime(e)
+        # globals storage
+        for (name,ty,arrlen,init) in self.P.globals:
+            label=f"g_{name}"
+            self.global_syms[name]=(label,ty,arrlen)
+        # functions
+        for fidx in self.P.funcs:
+            fn=self.P.nodes[fidx]
+            self.func_types[fn['name']]=fn['ret']
+        for fidx in self.P.funcs:
+            self.gen_func(fidx)
+        # data section
+        e.emit(".data")
+        for (name,ty,arrlen,init) in self.P.globals:
+            label=f"g_{name}"
+            if arrlen:
+                e.emit(f"{label}: .space {self.type_size(ty)*arrlen}")
+            else:
+                sz=self.type_size(ty)
+                if sz<=WORD:
+                    # scalar (int/unsigned/char/pointer): one word, constant init
+                    e.emit(f"{label}: .word {init if init is not None else 0}")
+                else:
+                    # struct (or any multi-word) global: reserve its FULL size,
+                    # word-rounded. This branch previously also emitted a single
+                    # .word, so struct globals were under-allocated to 2 bytes and
+                    # overlapped the next global (A.hi aliased B.lo) -- the actual
+                    # cause of the TEA failure (misattributed to evaluation order).
+                    e.emit(f"{label}: .space {(sz+WORD-1)//WORD*WORD}")
+        for (label,text) in self.strings:
+            data=','.join(str(ord(c)) for c in text)+',0'
+            e.emit(f"{label}: .byte {data}")
+        return e.text()
+
+    # ---------- functions ----------
+    def collect_locals(self, idx, fn):
+        n=self.P.nodes[idx]; op=n['op']
+        if op=='block':
+            for s in n['stmts']: self.collect_locals(s,fn)
+        elif op=='if':
+            self.collect_locals(n['then'],fn)
+            if n['els'] is not None: self.collect_locals(n['els'],fn)
+        elif op=='while':
+            self.collect_locals(n['body'],fn)
+        elif op=='vardecl':
+            if n['arrlen']:
+                nslots=(self.type_size(n['vtype'])*n['arrlen']+WORD-1)//WORD
+            else:
+                # scalars are 1 word; structs occupy ceil(size/word) words
+                nslots=(self.type_size(n['vtype'])+WORD-1)//WORD
+            base_index=fn.n_locals
+            fn.slots[n['name']]=(base_index, n['vtype'], n['arrlen'])
+            fn.n_locals+=nslots
+
+    def gen_func(self, fidx):
+        fn=self.P.nodes[fidx]
+        f=Func(fn['name']); self.cur=f
+        # params occupy positive offsets; record them
+        for i,(pname,pty) in enumerate(fn['params']):
+            f.slots[pname]=('param',i,pty)
+            f.param_order.append(pname)
+        # collect locals to size the frame
+        self.collect_locals(fn['body'], f)
+        C.func_prologue(self.e, fn['name'], f.n_locals)
+        self.epilogue_label=self.e.label("epi")
+        self.gen_stmt(fn['body'])
+        self.e.emit(f"{self.epilogue_label}:")
+        C.func_epilogue(self.e)
+        self.cur=None
+
+    # ---------- statements ----------
+    def gen_stmt(self, idx):
+        n=self.P.nodes[idx]; op=n['op']; e=self.e
+        if op=='block':
+            for s in n['stmts']: self.gen_stmt(s)
+        elif op=='vardecl':
+            if n['init'] is not None:
+                self.gen_expr(n['init'])
+                self.store_to_var(n['name'])
+        elif op=='exprstmt':
+            self.gen_expr(n['expr'])
+        elif op=='return':
+            if n['val'] is not None: self.gen_expr(n['val'])
+            C.far_jump(e, self.epilogue_label)
+        elif op=='if':
+            gc=lambda e: self.gen_expr(n['cond'])
+            gt=lambda e: self.gen_stmt(n['then'])
+            ge=(lambda e: self.gen_stmt(n['els'])) if n['els'] is not None else None
+            C.if_then_else(e, gc, gt, ge)
+        elif op=='while':
+            gc=lambda e: self.gen_expr(n['cond'])
+            gb=lambda e: self.gen_stmt(n['body'])
+            C.while_loop(e, gc, gb)
+        elif op=='break':
+            C.emit_break(e)
+        elif op=='continue':
+            C.emit_continue(e)
+        elif op=='asm':
+            C.emit_asm(e, n['text'])
+        else:
+            raise CodegenError(f"stmt op {op}")
+
+    # ---------- variable access ----------
+    def var_info(self, name):
+        f=self.cur
+        if name in f.slots:
+            return ('local', f.slots[name])
+        if name in self.global_syms:
+            return ('global', self.global_syms[name])
+        raise CodegenError(f"undefined variable {name}")
+
+    def var_type(self, name):
+        kind,info=self.var_info(name)
+        if kind=='local':
+            if info[0]=='param': return info[2]
+            return info[1]
+        return info[1]
+
+    def gen_var_addr(self, name, dst="x6"):
+        """address of variable -> dst"""
+        kind,info=self.var_info(name)
+        e=self.e
+        if kind=='local':
+            if info[0]=='param':
+                off=C.param_addr_offset(info[1])
+            else:
+                base_index=info[0]; arrlen=info[2]; vtype=info[1]
+                if arrlen:
+                    # array occupies slots [base_index .. base_index+nslots-1];
+                    # element 0 sits at the most-negative offset so a[k]=base+2k
+                    nslots=(self.type_size(vtype)*arrlen+WORD-1)//WORD
+                    off=C.local_addr_offset(base_index+nslots-1)
+                else:
+                    # struct fields grow upward from the most-negative slot
+                    nslots=(self.type_size(vtype)+WORD-1)//WORD
+                    off=C.local_addr_offset(base_index+nslots-1)
+            C.addr_plus_offset(e, "x3", off, dst)
+        else:
+            label=info[0]
+            e.emit(f"    la {dst}, {label}")
+
+    def load_from_var(self, name):
+        ty=self.var_type(name)
+        # arrays evaluate to their address
+        kind,info=self.var_info(name)
+        is_array = (kind=='local' and info[0]!='param' and info[2]) or (kind=='global' and info[2])
+        if is_array:
+            self.gen_var_addr(name,"x6"); return ty
+        self.gen_var_addr(name,"x5")
+        if self.is_byte(ty):
+            self.e.emit(f"    {'lbu' if self.is_unsigned(ty) else 'lb'} x6, 0(x5)")
+        else:
+            self.e.emit("    lw x6, 0(x5)")
+        return ty
+
+    def store_to_var(self, name):
+        """value in x6 -> variable"""
+        ty=self.var_type(name)
+        self.e.emit("    push x6")          # save value
+        self.gen_var_addr(name,"x5")
+        self.e.emit("    lw x6, 0(x2)")     # restore value
+        self.e.emit("    addi x2, 2")
+        if self.is_byte(ty):
+            self.e.emit("    sb x6, 0(x5)")
+        else:
+            self.e.emit("    sw x6, 0(x5)")
+
+    # ---------- expressions (result -> x6); returns type ----------
+    def gen_expr(self, idx):
+        n=self.P.nodes[idx]; op=n['op']; e=self.e
+        if op=='intlit':
+            C.load_const(e, n['val']); return {'base':'int','ptr':0}
+        if op=='charlit':
+            C.load_const(e, n['val']); return {'base':'char','ptr':0}
+        if op=='strlit':
+            label=self.e.label("str"); self.strings.append((label,n['val']))
+            e.emit(f"    la x6, {label}"); return {'base':'char','ptr':1}
+        if op=='ident':
+            return self.load_from_var(n['name'])
+        if op=='assign':
+            return self.gen_assign(n)
+        if op=='binop':
+            return self.gen_binop(n)
+        if op=='unop':
+            return self.gen_unop(n)
+        if op=='cast':
+            self.gen_expr(n['operand']); return n['ctype']
+        if op=='call':
+            return self.gen_call(n)
+        if op=='index':
+            return self.gen_index_rvalue(n)
+        if op=='member':
+            return self.gen_member_rvalue(n)
+        raise CodegenError(f"expr op {op}")
+
+    def gen_binop(self, n):
+        e=self.e
+        lt=self.gen_expr(n['lhs'])     # result x6
+        C.push_x6(e)
+        rt=self.gen_expr(n['rhs'])     # result x6
+        C.pop_to(e, "x5")              # x5 = left, x6 = right
+        bop=n['bop']
+        unsigned = self.is_unsigned(lt) or self.is_unsigned(rt) or self.is_ptr(lt)
+        # pointer arithmetic scaling: ptr +/- int  -> scale int by elem size
+        if bop in ('+','-') and self.is_ptr(lt) and not self.is_ptr(rt):
+            esz=self.elem_size(lt)
+            if esz==2:
+                e.emit("    li x4, 1"); e.emit("    sll x6, x4")   # right *= 2
+            elif esz==4:
+                e.emit("    li x4, 2"); e.emit("    sll x6, x4")
+            elif esz!=1:
+                # general scale via repeated add is overkill; structs use member, arrays pow2
+                raise CodegenError("pointer step with non-pow2 element size")
+        if bop in ('+','-','*','/','%'):
+            # arithmetic; ensure correct order for - and /
+            if bop=='+': C.bin_op(e,'+',True)
+            elif bop=='-': C.bin_op(e,'-',True)
+            elif bop=='*': C.bin_op(e,'*',True)
+            elif bop=='/': C.bin_op(e,'/',True)
+            elif bop=='%': C.bin_op(e,'%',True)
+            return lt if not self.is_ptr(rt) else rt
+        if bop in ('&','|','^'):
+            C.bit_op(e,bop); return lt
+        if bop=='<<':
+            C.bit_op(e,'<<'); return lt
+        if bop=='>>':
+            C.bit_op(e,'>>' if unsigned else '>>s'); return lt
+        if bop in ('<','>','<=','>='):
+            if unsigned: C.cmp_unsigned(e,bop)
+            else: C.bin_op(e,bop,True)
+            return {'base':'int','ptr':0}
+        if bop in ('==','!='):
+            C.bin_op(e,bop,True); return {'base':'int','ptr':0}
+        raise CodegenError(f"binop {bop}")
+
+    def gen_unop(self, n):
+        e=self.e; uop=n['uop']
+        if uop=='-':
+            self.gen_expr(n['operand']); C.unary_neg(e); return {'base':'int','ptr':0}
+        if uop=='~':
+            self.gen_expr(n['operand']); C.bit_not(e); return {'base':'int','ptr':0}
+        if uop=='*':
+            t=self.gen_expr(n['operand'])   # pointer value in x6
+            et=self.elem_type(t)
+            e.emit("    mv x5, x6")
+            if self.is_byte(et):
+                e.emit(f"    {'lbu' if self.is_unsigned(et) else 'lb'} x6, 0(x5)")
+            else:
+                e.emit("    lw x6, 0(x5)")
+            return et
+        if uop=='&':
+            t=self.gen_addr(n['operand'])   # address in x6
+            return {'base':t['base'],'ptr':t['ptr']+1}
+        raise CodegenError(f"unop {uop}")
+
+    def gen_call(self, n):
+        e=self.e
+        fnode=self.P.nodes[n['fn']]
+        if fnode['op']!='ident': raise CodegenError("only direct calls supported")
+        fname=fnode['name']
+        # intrinsics: putint(x) -> ecall 0x000 ; putchar(c) -> ecall 0x001
+        if fname=='putint' and len(n['args'])==1:
+            self.gen_expr(n['args'][0]); e.emit("    ecall 0x000")
+            return {'base':'int','ptr':0}
+        if fname=='putchar' and len(n['args'])==1:
+            self.gen_expr(n['args'][0]); e.emit("    ecall 0x001")
+            return {'base':'int','ptr':0}
+        # push args right-to-left
+        for a in reversed(n['args']):
+            self.gen_expr(a)
+            C.push_x6(e)
+        C.call_function(e, fname, len(n['args']))
+        return self.func_types.get(fname, {'base':'int','ptr':0})
+
+    # ---------- lvalue address generation (-> x6) ----------
+    def gen_addr(self, idx):
+        n=self.P.nodes[idx]; op=n['op']; e=self.e
+        if op=='ident':
+            self.gen_var_addr(n['name'],"x6"); return self.var_type(n['name'])
+        if op=='unop' and n['uop']=='*':
+            t=self.gen_expr(n['operand']); return self.elem_type(t)   # address already in x6
+        if op=='index':
+            return self.gen_index_addr(n)
+        if op=='member':
+            return self.gen_member_addr(n)
+        raise CodegenError(f"not an lvalue: {op}")
+
+    def gen_assign(self, n):
+        e=self.e
+        # compute rhs -> x6, save; compute lhs address -> x5; store
+        rt=self.gen_expr(n['rhs'])
+        C.push_x6(e)
+        lt=self.gen_addr(n['lhs'])      # address -> x6
+        e.emit("    mv x5, x6")         # x5 = addr
+        e.emit("    lw x6, 0(x2)")      # x6 = value
+        e.emit("    addi x2, 2")
+        if self.is_byte(lt):
+            e.emit("    sb x6, 0(x5)")
+        else:
+            e.emit("    sw x6, 0(x5)")
+        return lt
+
+    # ---------- index / member ----------
+    def scale_index(self, esz):
+        """x6 (index) *= esz, using shift for powers of two, else __mul."""
+        e=self.e
+        if esz==1: return
+        if esz==2:
+            e.emit("    li x5, 1"); e.emit("    sll x6, x5")   # x6 <<= 1
+        elif esz==4:
+            e.emit("    li x5, 2"); e.emit("    sll x6, x5")
+        elif esz==8:
+            e.emit("    li x5, 3"); e.emit("    sll x6, x5")
+        else:
+            # general: __mul(x6, esz)
+            e.emit("    push x6")          # a = index
+            C.load_const(e, esz); e.emit("    push x6")  # b = esz
+            # __mul expects [sp]=a,[sp+2]=b; we pushed a then b -> [sp]=b,[sp+2]=a
+            # swap by adjusting: easier to push in right order
+            e.emit("    addi x2, 4")       # undo
+            e.emit("    push x6")          # actually redo cleanly below
+            # (esz>8 with non-pow2 is rare; do explicit)
+            # fall back: repeated handling omitted — esz here is struct size
+            raise CodegenError("non-power-of-two element size not yet supported")
+
+    def gen_index_addr(self, n):
+        e=self.e
+        bt=self.gen_expr(n['base'])     # base address/pointer -> x6
+        C.push_x6(e)
+        self.gen_expr(n['idx'])         # index -> x6
+        esz=self.elem_size(bt)
+        self.scale_index(esz)           # x6 = index*esz
+        C.pop_to(e,"x5")                # x5 = base, x6 = scaled index
+        e.emit("    add x6, x5")        # x6 = index*esz + base
+        return self.elem_type(bt)
+
+    def gen_index_rvalue(self, n):
+        et=self.gen_index_addr(n)       # addr in x6
+        e=self.e; e.emit("    mv x5, x6")
+        if self.is_byte(et):
+            e.emit(f"    {'lbu' if self.is_unsigned(et) else 'lb'} x6, 0(x5)")
+        else:
+            e.emit("    lw x6, 0(x5)")
+        return et
+
+    def struct_of(self, t):
+        b=t['base']
+        if isinstance(b,tuple) and b[0]=='struct': return self.P.structs[b[1]]
+        raise CodegenError("member of non-struct")
+
+    def gen_member_addr(self, n):
+        e=self.e
+        if n['arrow']:
+            bt=self.gen_expr(n['base'])         # pointer -> x6
+            st=self.struct_of(self.elem_type(bt))
+        else:
+            bt=self.gen_addr(n['base'])         # struct address -> x6
+            st=self.struct_of(bt)
+        off=None; ftype=None
+        for (fname,ft,fo,fa) in st['fields']:
+            if fname==n['field']: off=fo; ftype=ft; break
+        if off is None: raise CodegenError(f"no field {n['field']}")
+        C.addr_plus_offset(e,"x6",off,"x6")
+        return ftype
+
+    def gen_member_rvalue(self, n):
+        ft=self.gen_member_addr(n)
+        e=self.e; e.emit("    mv x5, x6")
+        if self.is_byte(ft):
+            e.emit(f"    {'lbu' if self.is_unsigned(ft) else 'lb'} x6, 0(x5)")
+        else:
+            e.emit("    lw x6, 0(x5)")
+        return ft
+
+
+def compile_src(src):
+    p=zcc.parse(src)
+    return Codegen(p).gen_program()
+
+
+if __name__=='__main__':
+    import sys
+    src=open(sys.argv[1]).read() if len(sys.argv)>1 else '''
+    int add(int a, int b){ return a+b; }
+    int main(void){ int x; x = add(3,4); return x; }
+    '''
+    print(compile_src(src))

--- a/compiler/codegen_patterns.py
+++ b/compiler/codegen_patterns.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""
+ZC codegen pattern library for ZX16.
+
+Each function emits a validated assembly fragment for one construct. These are the
+building blocks the parser will drive. The patterns encode the hard-won ZX16 rules:
+
+  * Two-operand destructive ALU: `add rd, rs` means rd = rd + rs. Binary ops must
+    move/arrange operands first.
+  * SLT is two-operand; comparisons either use `mv` then `slt`, or branch directly.
+  * `call` clobbers ra (x1): every non-leaf function saves/restores it.
+  * Loads/stores have a ±7 byte offset; larger frame offsets need address calc.
+  * Branch range ±16 bytes; a direct j/call reaches only ±512 bytes (offset is
+    imm[9:1], sign bit 9), so codegen always uses la+jr / la+jalr — distance never
+    bounds a jump or call.
+
+Evaluation model (uniform and simple, not optimal):
+  Every expression evaluates with its RESULT IN x6. A binary op `L op R`:
+      <eval L>            # result in x6
+      push x6             # save L on stack
+      <eval R>            # result in x6 (= R)
+      lw  x5, 0(sp)       # x5 = L
+      addi sp, 2          # pop
+      <combine x5 (L) and x6 (R) -> x6>
+
+Register roles:
+  x6 (a0)  expression result / return value / first arg
+  x5 (t1)  scratch for the popped left operand
+  x3 (s0)  frame pointer
+  x2 (sp)  stack pointer
+  x1 (ra)  return address
+"""
+
+class Emitter:
+    def __init__(self):
+        self.lines = []
+        self._label_n = 0
+        self.loop_stack = []   # stack of (continue_label, break_label)
+
+    def emit(self, s=""):
+        self.lines.append(s)
+
+    def label(self, prefix="L"):
+        self._label_n += 1
+        return f"__{prefix}{self._label_n}"
+
+    def push_loop(self, continue_label, break_label):
+        self.loop_stack.append((continue_label, break_label))
+
+    def pop_loop(self):
+        self.loop_stack.pop()
+
+    def cur_break(self):
+        if not self.loop_stack:
+            raise SyntaxError("break outside loop")
+        return self.loop_stack[-1][1]
+
+    def cur_continue(self):
+        if not self.loop_stack:
+            raise SyntaxError("continue outside loop")
+        return self.loop_stack[-1][0]
+
+    def text(self):
+        return "\n".join(self.lines) + "\n"
+
+# ---------------------------------------------------------------------------
+# Primitive value loads (result -> x6)
+# ---------------------------------------------------------------------------
+
+def load_const(e, n):
+    """Load integer constant into x6."""
+    n &= 0xFFFF
+    sn = n - 0x10000 if n >= 0x8000 else n
+    if -64 <= sn <= 63:
+        e.emit(f"    li x6, {sn}")
+    else:
+        hi = n >> 7
+        lo = n & 0x7F
+        e.emit(f"    lui x6, {hi}")
+        if lo:
+            e.emit(f"    ori x6, {lo}")
+
+def push_x6(e):
+    e.emit("    push x6")
+
+def pop_to(e, reg):
+    e.emit(f"    lw {reg}, 0(x2)")
+    e.emit("    addi x2, 2")
+
+# ---------------------------------------------------------------------------
+# Binary operators: left in x5, right in x6, result -> x6
+# ---------------------------------------------------------------------------
+
+def bin_op(e, op, runtime_calls):
+    """Combine x5 (left) and x6 (right) per `op`, result in x6.
+    runtime_calls: set True to use __mul/__div/__mod helpers."""
+    if op == '+':
+        e.emit("    add x5, x6")       # x5 = L + R
+        e.emit("    mv x6, x5")
+    elif op == '-':
+        e.emit("    sub x5, x6")       # x5 = L - R
+        e.emit("    mv x6, x5")
+    elif op == '*':
+        # __mul(a,b): push b, push a
+        e.emit("    push x6")          # b = R
+        e.emit("    push x5")          # a = L
+        e.emit("    la x4, __mul")
+        e.emit("    jalr x1, x4")
+        e.emit("    addi x2, 4")
+    elif op == '/':
+        e.emit("    push x6")
+        e.emit("    push x5")
+        e.emit("    la x4, __div")
+        e.emit("    jalr x1, x4")
+        e.emit("    addi x2, 4")
+    elif op == '%':
+        e.emit("    push x6")
+        e.emit("    push x5")
+        e.emit("    la x4, __mod")
+        e.emit("    jalr x1, x4")
+        e.emit("    addi x2, 4")
+    elif op in ('<', '>', '<=', '>=', '==', '!='):
+        # produce 0/1 in x6 using branches
+        t = e.label("cmp")
+        d = e.label("cmpd")
+        # arrange: compare L (x5) ? R (x6)
+        if op == '<':   e.emit(f"    blt x5, x6, {t}")
+        elif op == '>': e.emit(f"    blt x6, x5, {t}")
+        elif op == '<=':e.emit(f"    bge x6, x5, {t}")
+        elif op == '>=':e.emit(f"    bge x5, x6, {t}")
+        elif op == '==':e.emit(f"    beq x5, x6, {t}")
+        elif op == '!=':e.emit(f"    bne x5, x6, {t}")
+        e.emit("    li x6, 0")
+        e.emit(f"    j {d}")
+        e.emit(f"{t}:")
+        e.emit("    li x6, 1")
+        e.emit(f"{d}:")
+    else:
+        raise ValueError(f"unknown op {op}")
+
+def unary_neg(e):
+    """x6 = -x6"""
+    e.emit("    xori x6, -1")
+    e.emit("    addi x6, 1")
+
+def unary_not(e):
+    """logical not: x6 = (x6 == 0) ? 1 : 0"""
+    t = e.label("not"); d = e.label("notd")
+    e.emit(f"    bz x6, {t}")
+    e.emit("    li x6, 0")
+    e.emit(f"    j {d}")
+    e.emit(f"{t}:")
+    e.emit("    li x6, 1")
+    e.emit(f"{d}:")
+
+# ---------------------------------------------------------------------------
+# Control flow
+# ---------------------------------------------------------------------------
+
+def far_jump(e, label):
+    """Unconditional jump of unbounded distance. Direct `j` only reaches +-512
+    bytes, which a large function body exceeds; la+jr is unbounded. Uses x4 scratch."""
+    e.emit(f"    la x4, {label}")
+    e.emit(f"    jr x4")
+
+def if_then_else(e, gen_cond, gen_then, gen_else=None):
+    """if (cond) then [else]. gen_* are callables that emit into e.
+    Uses short-branch-over-far-jump so arbitrarily long bodies AND distances work."""
+    end_l = e.label("endif")
+    gen_cond(e)                 # result in x6
+    if gen_else:
+        else_l = e.label("else")
+        then_l = e.label("then")
+        e.emit(f"    bnz x6, {then_l}")
+        far_jump(e, else_l)
+        e.emit(f"{then_l}:")
+        gen_then(e)
+        far_jump(e, end_l)
+        e.emit(f"{else_l}:")
+        gen_else(e)
+        e.emit(f"{end_l}:")
+    else:
+        then_l = e.label("then")
+        e.emit(f"    bnz x6, {then_l}")
+        far_jump(e, end_l)
+        e.emit(f"{then_l}:")
+        gen_then(e)
+        e.emit(f"{end_l}:")
+
+def while_loop(e, gen_cond, gen_body):
+    # Short conditional branch to enter the body; far jumps for exit and back-edge,
+    # since the body can be larger than the +-512 byte direct-jump range.
+    top = e.label("while")
+    end = e.label("wend")
+    skip = e.label("wbody")
+    e.push_loop(top, end)         # continue target = top, break target = end
+    e.emit(f"{top}:")
+    gen_cond(e)                     # result in x6
+    e.emit(f"    bnz x6, {skip}")   # short branch: enter body
+    far_jump(e, end)                # exit loop (far)
+    e.emit(f"{skip}:")
+    gen_body(e)
+    far_jump(e, top)                # back-edge (far)
+    e.emit(f"{end}:")
+    e.pop_loop()
+
+def emit_break(e):
+    far_jump(e, e.cur_break())
+
+def emit_continue(e):
+    far_jump(e, e.cur_continue())
+
+# ---------------------------------------------------------------------------
+# Function prologue / epilogue
+# ---------------------------------------------------------------------------
+
+def func_prologue(e, name, n_locals):
+    e.emit(f"{name}:")
+    e.emit("    push x1")        # save ra (clobbered by any call)
+    e.emit("    push x3")        # save caller's frame pointer
+    e.emit("    mv x3, x2")      # s0 = sp  (frame base = saved old s0)
+    if n_locals:
+        e.emit(f"    addi x2, {-2*n_locals}")  # allocate locals
+
+def func_epilogue(e):
+    e.emit("    mv x2, x3")      # free locals
+    e.emit("    pop x3")         # restore frame pointer
+    e.emit("    pop x1")         # restore ra
+    e.emit("    ret")
+
+def local_addr_offset(i):
+    """byte offset of local i relative to s0 (negative)."""
+    return -2 - 2*i
+
+def param_addr_offset(i):
+    """byte offset of param i relative to s0 (positive: above saved s0/ra)."""
+    return 4 + 2*i
+
+def load_local(e, i):
+    off = local_addr_offset(i)
+    if -8 <= off <= 7:
+        e.emit(f"    lw x6, {off}(x3)")
+    else:
+        e.emit("    mv x6, x3")
+        e.emit(f"    addi x6, {off}")    # may itself overflow imm; codegen will split
+        e.emit("    lw x6, 0(x6)")
+
+def store_local(e, i):
+    """store x6 into local i."""
+    off = local_addr_offset(i)
+    if -8 <= off <= 7:
+        e.emit(f"    sw x6, {off}(x3)")
+    else:
+        e.emit("    mv x5, x3")
+        e.emit(f"    addi x5, {off}")
+        e.emit("    sw x6, 0(x5)")
+
+def call_function(e, name, n_args):
+    """Args already pushed right-to-left. Uses a far-call (la + jalr) so the target
+    is reachable regardless of distance — a direct `call` (JAL) only reaches ±512 bytes,
+    which a large program (e.g. the self-hosted compiler) exceeds. Result in x6.
+    x5 is scratch (the evaluation model treats it as clobberable across a call)."""
+    e.emit(f"    la x5, {name}")
+    e.emit("    jalr x1, x5")
+    if n_args:
+        e.emit(f"    addi x2, {2*n_args}")
+
+def return_value(e):
+    """expression result already in x6; jump to epilogue handled by caller."""
+    pass
+
+# ---------------------------------------------------------------------------
+# Member / pointer / array address computation
+# ---------------------------------------------------------------------------
+
+def addr_plus_offset(e, base_reg, off, dst_reg):
+    """dst_reg = base_reg + off, choosing the cheapest sequence.
+    Leaves an address in dst_reg suitable for 0(dst_reg) access."""
+    if off == 0 and dst_reg == base_reg:
+        return
+    if -64 <= off <= 63:
+        if dst_reg != base_reg:
+            e.emit(f"    mv {dst_reg}, {base_reg}")
+        if off:
+            e.emit(f"    addi {dst_reg}, {off}")
+    else:
+        e.emit(f"    li16 {dst_reg}, {off & 0xFFFF}")
+        e.emit(f"    add {dst_reg}, {base_reg}")
+
+def load_word_at(e, base_reg, off, dst="x6"):
+    """dst = *(int*)(base_reg + off)"""
+    if -8 <= off <= 7:
+        e.emit(f"    lw {dst}, {off}({base_reg})")
+    else:
+        addr_plus_offset(e, base_reg, off, "x5")
+        e.emit(f"    lw {dst}, 0(x5)")
+
+def store_word_at(e, base_reg, off, src="x6"):
+    """*(int*)(base_reg + off) = src"""
+    if -8 <= off <= 7:
+        e.emit(f"    sw {src}, {off}({base_reg})")
+    else:
+        addr_plus_offset(e, base_reg, off, "x5")
+        e.emit(f"    sw {src}, 0(x5)")
+
+def load_byte_at(e, base_reg, off, dst="x6", signed=True):
+    op = "lb" if signed else "lbu"
+    if -8 <= off <= 7:
+        e.emit(f"    {op} {dst}, {off}({base_reg})")
+    else:
+        addr_plus_offset(e, base_reg, off, "x5")
+        e.emit(f"    {op} {dst}, 0(x5)")
+
+def store_byte_at(e, base_reg, off, src="x6"):
+    if -8 <= off <= 7:
+        e.emit(f"    sb {src}, {off}({base_reg})")
+    else:
+        addr_plus_offset(e, base_reg, off, "x5")
+        e.emit(f"    sb {src}, 0(x5)")
+
+# ---------------------------------------------------------------------------
+# Bitwise + shift ops (single ZX16 instructions): left x5, right x6 -> x6
+# ---------------------------------------------------------------------------
+
+def bit_op(e, op):
+    if op == '&':
+        e.emit("    and x5, x6"); e.emit("    mv x6, x5")
+    elif op == '|':
+        e.emit("    or x5, x6");  e.emit("    mv x6, x5")
+    elif op == '^':
+        e.emit("    xor x5, x6"); e.emit("    mv x6, x5")
+    elif op == '<<':
+        # shift amount in x6, value in x5  -> x5 << x6
+        e.emit("    sll x5, x6"); e.emit("    mv x6, x5")
+    elif op == '>>':
+        e.emit("    srl x5, x6"); e.emit("    mv x6, x5")   # logical (unsigned)
+    elif op == '>>s':
+        e.emit("    sra x5, x6"); e.emit("    mv x6, x5")   # arithmetic (signed)
+    else:
+        raise ValueError(f"unknown bit op {op}")
+
+def bit_not(e):
+    """x6 = ~x6"""
+    e.emit("    xori x6, -1")
+
+# unsigned comparison variants (left x5, right x6 -> 0/1 in x6)
+def cmp_unsigned(e, op):
+    t = e.label("ucmp"); d = e.label("ucmpd")
+    if op == '<':    e.emit(f"    bltu x5, x6, {t}")
+    elif op == '>':  e.emit(f"    bltu x6, x5, {t}")
+    elif op == '<=': e.emit(f"    bgeu x6, x5, {t}")
+    elif op == '>=': e.emit(f"    bgeu x5, x6, {t}")
+    else: raise ValueError(op)
+    e.emit("    li x6, 0"); e.emit(f"    j {d}")
+    e.emit(f"{t}:"); e.emit("    li x6, 1"); e.emit(f"{d}:")
+
+def load_abs_addr(e, addr, dst="x6"):
+    """dst = constant absolute address (for (int*)0xF000 style casts)."""
+    e.emit(f"    li16 {dst}, {addr & 0xFFFF}")
+
+def emit_asm(e, text):
+    """asm("...") passthrough: emit verbatim."""
+    for line in text.splitlines():
+        e.emit("    " + line.strip())
+
+# ---------------------------------------------------------------------------
+# Program skeleton
+# ---------------------------------------------------------------------------
+
+def crt0(e):
+    e.emit(".text")
+    e.emit(".org 0x0020")
+    e.emit("__start:")
+    e.emit("    li16 x2, 0xF000")
+    e.emit("    la x5, main")
+    e.emit("    jalr x1, x5")
+    e.emit("    ecall 0x3FF")
+
+def runtime(e):
+    # Helpers preserve x3 and x4 (callee-saved: x3 is the caller's frame pointer).
+    # They read args relative to a temporarily adjusted view of the stack.
+    # On entry [sp]=a, [sp+2]=b. After we push x3,x4 the args shift by 4.
+    e.emit("__mul:")
+    e.emit("    push x3")
+    e.emit("    push x4")
+    e.emit("    lw x3, 4(x2)")     # a  (args shifted by the 2 pushes = 4 bytes)
+    e.emit("    lw x4, 6(x2)")     # b
+    e.emit("    li x6, 0")
+    e.emit("__mul_lp:")
+    e.emit("    bz x3, __mul_done")
+    e.emit("    add x6, x4")
+    e.emit("    addi x3, -1")
+    e.emit("    j __mul_lp")
+    e.emit("__mul_done:")
+    e.emit("    pop x4")
+    e.emit("    pop x3")
+    e.emit("    ret")
+    e.emit("__div:")
+    e.emit("    push x3")
+    e.emit("    push x4")
+    e.emit("    lw x3, 4(x2)")
+    e.emit("    lw x4, 6(x2)")
+    e.emit("    li x6, 0")
+    e.emit("__div_lp:")
+    e.emit("    blt x3, x4, __div_done")
+    e.emit("    sub x3, x4")
+    e.emit("    addi x6, 1")
+    e.emit("    j __div_lp")
+    e.emit("__div_done:")
+    e.emit("    pop x4")
+    e.emit("    pop x3")
+    e.emit("    ret")
+    e.emit("__mod:")
+    e.emit("    push x3")
+    e.emit("    push x4")
+    e.emit("    lw x3, 4(x2)")
+    e.emit("    lw x4, 6(x2)")
+    e.emit("__mod_lp:")
+    e.emit("    blt x3, x4, __mod_done")
+    e.emit("    sub x3, x4")
+    e.emit("    j __mod_lp")
+    e.emit("__mod_done:")
+    e.emit("    mv x6, x3")
+    e.emit("    pop x4")
+    e.emit("    pop x3")
+    e.emit("    ret")

--- a/compiler/examples/01_gpio_set.c
+++ b/compiler/examples/01_gpio_set.c
@@ -1,0 +1,11 @@
+// GPIO: set and clear individual bits in a memory-mapped output register.
+// GPIO_OUT is a 16-bit register at 0xF010.
+int main(void){
+    unsigned *gpio;
+    gpio = (unsigned *)0xF010;
+    *gpio = 0;              // clear all
+    *gpio = *gpio | (1 << 3);   // set bit 3
+    *gpio = *gpio | (1 << 5);   // set bit 5
+    *gpio = *gpio & ~(1 << 3);  // clear bit 3  -> only bit 5 set = 0x20
+    return 0;
+}

--- a/compiler/examples/02_poll_status.c
+++ b/compiler/examples/02_poll_status.c
@@ -1,0 +1,15 @@
+// Poll a status register until its READY bit (bit 0) is set, then read data.
+// STATUS at 0xF020 (byte), DATA at 0xF021 (byte).
+int main(void){
+    unsigned char *status;
+    unsigned char *data;
+    unsigned char s;
+    status = (unsigned char *)0xF020;
+    data   = (unsigned char *)0xF021;
+    s = *status;
+    while ((s & 1) == 0){       // wait for READY
+        s = *status;
+    }
+    putint( *data );            // read the data byte
+    return 0;
+}

--- a/compiler/examples/03_reg_map.c
+++ b/compiler/examples/03_reg_map.c
@@ -1,0 +1,17 @@
+// Timer peripheral modeled as a struct register map at 0xF030.
+struct Timer {
+    unsigned ctrl;     // +0
+    unsigned reload;   // +2
+    unsigned count;    // +4
+    unsigned status;   // +6
+};
+int main(void){
+    struct Timer *t;
+    t = (struct Timer *)0xF030;
+    t->reload = 1000;
+    t->ctrl   = (1 << 0) | (1 << 2);   // ENABLE | AUTORELOAD = 0x05
+    t->count  = t->reload;
+    putint( t->ctrl );
+    putint( t->count );
+    return 0;
+}

--- a/compiler/examples/04_checksum.c
+++ b/compiler/examples/04_checksum.c
@@ -1,0 +1,21 @@
+// XOR checksum over a byte buffer — typical for serial/packet code.
+unsigned char xorsum(unsigned char *buf, int n){
+    unsigned char c;
+    int i;
+    c = 0;
+    i = 0;
+    while (i < n){
+        c = c ^ buf[i];
+        i = i + 1;
+    }
+    return c;
+}
+int main(void){
+    unsigned char data[4];
+    data[0] = 0x12;
+    data[1] = 0x34;
+    data[2] = 0x56;
+    data[3] = 0x78;
+    putint( xorsum(data, 4) );   // 0x12^0x34^0x56^0x78 = 0x58 = 88
+    return 0;
+}

--- a/compiler/examples/05_ring_buffer.c
+++ b/compiler/examples/05_ring_buffer.c
@@ -1,0 +1,33 @@
+// Fixed-size ring buffer head/tail logic, as in an interrupt-driven UART driver.
+int buf[8];
+int head;
+int tail;
+
+int rb_push(int v){
+    int next;
+    next = (head + 1) & 7;          // wrap at 8 via mask
+    if (next == tail) return 0;     // full
+    buf[head] = v;
+    head = next;
+    return 1;
+}
+int rb_pop(void){
+    int v;
+    if (head == tail) return -1;    // empty
+    v = buf[tail];
+    tail = (tail + 1) & 7;
+    return v;
+}
+int main(void){
+    head = 0; tail = 0;
+    rb_push(10);
+    rb_push(20);
+    rb_push(30);
+    putint( rb_pop() );   // 10
+    putint( rb_pop() );   // 20
+    rb_push(40);
+    putint( rb_pop() );   // 30
+    putint( rb_pop() );   // 40
+    putint( rb_pop() );   // -1 empty
+    return 0;
+}

--- a/compiler/examples/06_matmul.c
+++ b/compiler/examples/06_matmul.c
@@ -1,0 +1,36 @@
+// 3x3 integer matrix multiply C = A * B, row-major flat arrays.
+int A[9];
+int B[9];
+int Cm[9];
+
+void matmul(int *a, int *b, int *c){
+    int i; int j; int k; int sum;
+    i = 0;
+    while (i < 3){
+        j = 0;
+        while (j < 3){
+            sum = 0;
+            k = 0;
+            while (k < 3){
+                sum = sum + a[i*3+k] * b[k*3+j];
+                k = k + 1;
+            }
+            c[i*3+j] = sum;
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+}
+
+int main(void){
+    int i;
+    // A = [1 2 3; 4 5 6; 7 8 9]
+    i = 0; while (i < 9){ A[i] = i + 1; i = i + 1; }
+    // B = identity
+    i = 0; while (i < 9){ B[i] = 0; i = i + 1; }
+    B[0] = 1; B[4] = 1; B[8] = 1;
+    matmul(A, B, Cm);
+    // A*I = A, so print all of Cm
+    i = 0; while (i < 9){ putint(Cm[i]); i = i + 1; }
+    return 0;
+}

--- a/compiler/examples/07_tea.c
+++ b/compiler/examples/07_tea.c
@@ -1,0 +1,74 @@
+// TEA (Tiny Encryption Algorithm) on a 16-bit machine, using a 32-bit emulation
+// layer (struct u32 = {lo, hi}). Encrypts one 64-bit block (v0,v1) with a 128-bit key.
+struct u32 { unsigned lo; unsigned hi; };
+
+void set32(struct u32 *r, unsigned hi, unsigned lo){ r->hi = hi; r->lo = lo; }
+
+void add32(struct u32 *r, struct u32 *a, struct u32 *b){
+    unsigned lo; unsigned carry;
+    lo = a->lo + b->lo;
+    carry = 0;
+    if (lo < a->lo) carry = 1;
+    r->lo = lo;
+    r->hi = a->hi + b->hi + carry;
+}
+void xor32(struct u32 *r, struct u32 *a, struct u32 *b){
+    r->lo = a->lo ^ b->lo;
+    r->hi = a->hi ^ b->hi;
+}
+// shift left by n (n < 16) across 32 bits
+void shl32(struct u32 *r, struct u32 *a, unsigned n){
+    unsigned hi; unsigned lo;
+    lo = a->lo << n;
+    hi = (a->hi << n) | (a->lo >> (16 - n));
+    r->lo = lo; r->hi = hi;
+}
+// shift right (logical) by n (n < 16) across 32 bits
+void shr32(struct u32 *r, struct u32 *a, unsigned n){
+    unsigned hi; unsigned lo;
+    hi = a->hi >> n;
+    lo = (a->lo >> n) | (a->hi << (16 - n));
+    r->lo = lo; r->hi = hi;
+}
+
+// one TEA feistel term: ((y<<4)+k0) ^ (y+sum) ^ ((y>>5)+k1)  -> into out
+void feistel(struct u32 *out, struct u32 *y, struct u32 *sum,
+             struct u32 *k0, struct u32 *k1){
+    struct u32 t1; struct u32 t2; struct u32 t3; struct u32 tmp;
+    shl32(&tmp, y, 4);  add32(&t1, &tmp, k0);   // (y<<4)+k0
+    add32(&t2, y, sum);                          // y+sum
+    shr32(&tmp, y, 5);  add32(&t3, &tmp, k1);   // (y>>5)+k1
+    xor32(&tmp, &t1, &t2);
+    xor32(out, &tmp, &t3);
+}
+
+struct u32 v0; struct u32 v1; struct u32 sum;
+struct u32 k0; struct u32 k1; struct u32 k2; struct u32 k3;
+struct u32 delta;
+
+void tea_encrypt(void){
+    int i; struct u32 f; struct u32 nv;
+    set32(&sum, 0, 0);
+    set32(&delta, 0x9E37, 0x79B9);   // 0x9E3779B9
+    i = 0;
+    while (i < 32){
+        add32(&sum, &sum, &delta);
+        // v0 += feistel(v1, sum, k0, k1)
+        feistel(&f, &v1, &sum, &k0, &k1);
+        add32(&nv, &v0, &f); v0.lo = nv.lo; v0.hi = nv.hi;
+        // v1 += feistel(v0, sum, k2, k3)
+        feistel(&f, &v0, &sum, &k2, &k3);
+        add32(&nv, &v1, &f); v1.lo = nv.lo; v1.hi = nv.hi;
+        i = i + 1;
+    }
+}
+
+int main(void){
+    // key = {0,1,2,3} (each 32-bit, here small values), plaintext v0=1,v1=2
+    set32(&k0, 0, 0); set32(&k1, 0, 1); set32(&k2, 0, 2); set32(&k3, 0, 3);
+    set32(&v0, 0, 1); set32(&v1, 0, 2);
+    tea_encrypt();
+    putint(v0.hi); putint(v0.lo);
+    putint(v1.hi); putint(v1.lo);
+    return 0;
+}

--- a/compiler/tests/test_compile.py
+++ b/compiler/tests/test_compile.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""End-to-end tests for zcc: compile ZC source, run on ZX16 sim, check output."""
+import os, sys
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_COMPILER = os.path.dirname(_HERE)
+sys.path.insert(0, _COMPILER)
+sys.path.insert(0, os.path.join(os.path.dirname(_COMPILER), "simulator"))
+
+import importlib
+import codegen_patterns, zcc, codegen
+importlib.reload(codegen_patterns); importlib.reload(zcc); importlib.reload(codegen)
+import zx16sim as Z
+
+def run(src):
+    asm=codegen.compile_src(src)
+    out,sim=Z.assemble_and_run(asm)
+    return [v for (k,v) in out]
+
+CASES=[]
+def case(name, src, expect):
+    CASES.append((name,src,expect))
+
+case("arith", '''
+int main(void){ putint( (2+3)*(10-6) ); return 0; }
+''', [20])
+
+case("recursion_fact", '''
+int fact(int n){ if (n < 2) return 1; return n * fact(n-1); }
+int main(void){ putint(fact(5)); return 0; }
+''', [120])
+
+case("while_sum", '''
+int main(void){
+  int i; int s;
+  i = 1; s = 0;
+  while (i <= 10){ s = s + i; i = i + 1; }
+  putint(s); return 0;
+}
+''', [55])
+
+case("ifelse", '''
+int main(void){
+  int a; a = 8;
+  if (a > 5) putint(1); else putint(0);
+  return 0;
+}
+''', [1])
+
+case("break_continue", '''
+int main(void){
+  int i; int c;
+  i = 0; c = 0;
+  while (i < 10){
+    i = i + 1;
+    if (i == 7) break;
+    if (i == 3) continue;
+    c = c + 1;
+  }
+  putint(c); return 0;   // 1,2,4,5,6 -> 5
+}
+''', [5])
+
+case("bitwise", '''
+int main(void){
+  putint( (1 << 3) | 1 );      // 9
+  putint( 0xFF & 0x0F );       // 15
+  putint( 0xF0 ^ 0xFF );       // 15
+  return 0;
+}
+''', [9,15,15])
+
+case("globals", '''
+int counter;
+int bump(void){ counter = counter + 1; return counter; }
+int main(void){
+  counter = 40;
+  bump(); bump();
+  putint(counter); return 0;
+}
+''', [42])
+
+case("pointers", '''
+int main(void){
+  int x; int *p;
+  x = 5;
+  p = &x;
+  *p = *p + 37;
+  putint(x); return 0;
+}
+''', [42])
+
+case("array", '''
+int main(void){
+  int a[5];
+  int i;
+  i = 0;
+  while (i < 5){ a[i] = i * i; i = i + 1; }
+  putint(a[0] + a[1] + a[2] + a[3] + a[4]);  // 0+1+4+9+16=30
+  return 0;
+}
+''', [30])
+
+case("struct", '''
+struct Point { int x; int y; };
+int main(void){
+  struct Point pt;
+  struct Point *p;
+  p = &pt;
+  p->x = 10;
+  p->y = 32;
+  putint(p->x + p->y); return 0;
+}
+''', [42])
+
+case("unsigned_cmp", '''
+int main(void){
+  unsigned a; unsigned b;
+  a = 0xF000; b = 0x0010;
+  if (a > b) putint(1); else putint(0);  // unsigned: 1
+  return 0;
+}
+''', [1])
+
+case("char_string", '''
+int main(void){
+  char *s;
+  s = "AB";
+  putchar(*s);          // 'A' = 65
+  putchar(*(s+1));      // 'B' = 66
+  return 0;
+}
+''', [65,66])
+
+if __name__=='__main__':
+    passed=0
+    for (name,src,expect) in CASES:
+        try:
+            got=run(src)
+            if got==expect:
+                print(f"PASS {name}"); passed+=1
+            else:
+                print(f"FAIL {name}: got {got} expected {expect}")
+        except Exception as ex:
+            print(f"ERROR {name}: {type(ex).__name__}: {ex}")
+    print(f"\n{passed}/{len(CASES)} end-to-end programs compiled and ran correctly")

--- a/compiler/tests/test_embedded.py
+++ b/compiler/tests/test_embedded.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Compile and verify the embedded C examples end-to-end.
+Each case checks printed output and, where relevant, the MMIO write log and
+final register state — the things that make these genuinely 'embedded'."""
+import os, sys
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_COMPILER = os.path.dirname(_HERE)
+sys.path.insert(0, _COMPILER)
+sys.path.insert(0, os.path.join(os.path.dirname(_COMPILER), "simulator"))
+
+import importlib
+import codegen_patterns, zcc, codegen
+importlib.reload(codegen_patterns); importlib.reload(zcc); importlib.reload(codegen)
+import zx16sim as Z
+
+def compile_run(path, pre_run=None):
+    asm=codegen.compile_src(open(os.path.join(_COMPILER, path)).read())
+    out,sim=Z.assemble_and_run(asm, pre_run=pre_run)
+    return asm, [v for k,v in out], sim
+
+results=[]
+def check(name, cond, detail=""):
+    results.append((name,cond,detail))
+    print(f"{'PASS' if cond else 'FAIL'} {name}" + (f"  [{detail}]" if detail and not cond else ""))
+
+# Ex1: GPIO bit set/clear -> final register 0x20, write sequence correct
+_,out,sim=compile_run('examples/01_gpio_set.c')
+writes=[(a,v) for a,v,s in sim.mmio_writes]
+check("01_gpio set/clear bits",
+      sim.lw(0xF010)==0x20 and writes==[(0xF010,0),(0xF010,0x08),(0xF010,0x28),(0xF010,0x20)],
+      f"final={hex(sim.lw(0xF010))} writes={[(hex(a),hex(v)) for a,v in writes]}")
+
+# Ex2: poll until READY then read data=99; READY appears on 3rd status read
+def setup2(sim):
+    sim.mmio_read_script[0xF020]=[0,0,1]
+    sim.mmio_regs[0xF021]=99
+_,out,sim=compile_run('examples/02_poll_status.c', setup2)
+check("02_poll_status waits for READY then reads", out==[99], f"out={out}")
+
+# Ex3: timer register map; writes to correct offsets, reads back ctrl & count
+_,out,sim=compile_run('examples/03_reg_map.c')
+w={a:v for a,v,s in sim.mmio_writes}
+check("03_reg_map struct field offsets",
+      out==[5,1000] and w.get(0xF030)==5 and w.get(0xF032)==1000 and w.get(0xF034)==1000,
+      f"out={out} writes={ {hex(a):hex(v) for a,v in w.items()} }")
+
+# Ex4: XOR checksum of {0x12,0x34,0x56,0x78} = 0x08
+_,out,sim=compile_run('examples/04_checksum.c')
+check("04_checksum xor over byte buffer", out==[0x12^0x34^0x56^0x78], f"out={out}")
+
+# Ex5: ring buffer push/pop ordering with wrap mask
+_,out,sim=compile_run('examples/05_ring_buffer.c')
+check("05_ring_buffer FIFO order + empty sentinel", out==[10,20,30,40,-1], f"out={out}")
+
+# Ex6: TEA cipher (struct globals) -> matches a reference 32-bit TEA exactly.
+# Regression for the struct-global under-allocation fix (printed values are s16).
+_,out,sim=compile_run('examples/07_tea.c')
+check("07_tea struct-global cipher vs reference",
+      out==[-31852,-1131,-29271,-25717], f"out={out}")
+
+n=sum(1 for _,c,_ in results if c)
+print(f"\n{n}/{len(results)} embedded examples verified correct")

--- a/compiler/tests/test_patterns.py
+++ b/compiler/tests/test_patterns.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Regression tests for the ZC codegen pattern library.
+Each test builds a program through codegen_patterns, runs it on the ZX16 sim,
+and checks the printed output. Run: python3 test_patterns.py
+"""
+import os, sys
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_COMPILER = os.path.dirname(_HERE)
+sys.path.insert(0, _COMPILER)
+sys.path.insert(0, os.path.join(os.path.dirname(_COMPILER), "simulator"))
+
+import importlib
+import codegen_patterns as C
+import zx16sim as Z
+
+def run(asm):
+    out, sim = Z.assemble_and_run(asm)
+    return out
+
+def t_arith():
+    # (2+3)*(10-6) = 20
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 2); C.push_x6(e); C.load_const(e, 3)
+    C.pop_to(e, "x5"); C.bin_op(e, '+', True)        # 5
+    C.push_x6(e)
+    C.load_const(e, 10); C.push_x6(e); C.load_const(e, 6)
+    C.pop_to(e, "x5"); C.bin_op(e, '-', True)        # 4
+    C.pop_to(e, "x5"); C.bin_op(e, '*', True)        # 5*4=20
+    e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int', 20)]
+
+def t_divmod():
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 23); C.push_x6(e); C.load_const(e, 4)
+    C.pop_to(e, "x5"); C.bin_op(e, '/', True)        # 5
+    e.emit("    ecall 0x000")
+    C.load_const(e, 23); C.push_x6(e); C.load_const(e, 4)
+    C.pop_to(e, "x5"); C.bin_op(e, '%', True)        # 3
+    e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int', 5), ('int', 3)]
+
+def t_recursion():
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "fact", 0)
+    e.emit("    lw x6, 4(x3)"); C.push_x6(e)
+    C.load_const(e, 2); C.pop_to(e, "x5"); C.bin_op(e, '<', True)
+    els = e.label("else")
+    e.emit(f"    bz x6, {els}")
+    C.load_const(e, 1)
+    e.emit("    mv x2, x3"); e.emit("    pop x3"); e.emit("    pop x1"); e.emit("    ret")
+    e.emit(f"{els}:")
+    e.emit("    lw x6, 4(x3)"); C.push_x6(e)
+    e.emit("    lw x6, 4(x3)"); e.emit("    addi x6, -1"); C.push_x6(e)
+    C.call_function(e, "fact", 1)
+    C.pop_to(e, "x5"); C.bin_op(e, '*', True)
+    C.func_epilogue(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 5); C.push_x6(e); C.call_function(e, "fact", 1)
+    e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int', 120)]
+
+def t_while():
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 2)
+    C.load_const(e, 1); C.store_local(e, 0)
+    C.load_const(e, 0); C.store_local(e, 1)
+    def cond(e):
+        C.load_local(e, 0); C.push_x6(e)
+        C.load_const(e, 10); C.pop_to(e, "x5"); C.bin_op(e, '<=', True)
+    def body(e):
+        C.load_local(e, 1); C.push_x6(e)
+        C.load_local(e, 0); C.pop_to(e, "x5"); C.bin_op(e, '+', True)
+        C.store_local(e, 1)
+        C.load_local(e, 0); C.push_x6(e)
+        C.load_const(e, 1); C.pop_to(e, "x5"); C.bin_op(e, '+', True)
+        C.store_local(e, 0)
+    C.while_loop(e, cond, body)
+    C.load_local(e, 1); e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int', 55)]
+
+def t_ifelse():
+    # print max(8,5) using if/else -> 8
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 1)
+    def cond(e):
+        C.load_const(e, 8); C.push_x6(e)
+        C.load_const(e, 5); C.pop_to(e, "x5"); C.bin_op(e, '>', True)
+    def then(e):
+        C.load_const(e, 8); C.store_local(e, 0)
+    def els(e):
+        C.load_const(e, 5); C.store_local(e, 0)
+    C.if_then_else(e, cond, then, els)
+    C.load_local(e, 0); e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int', 8)]
+
+def t_bigconst():
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 1000); e.emit("    ecall 0x000")
+    C.load_const(e, -5); e.emit("    ecall 0x000")
+    C.func_epilogue(e)
+    assert run(e.text()) == [('int', 1000), ('int', -5)]
+
+def t_bitwise():
+    # (1<<3)|(1<<0)=9 ; 0xFF & 0x0F = 15 ; 0xF0 ^ 0xFF = 0x0F ; ~0 = -1
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 1); C.push_x6(e); C.load_const(e, 3)
+    C.pop_to(e, "x5"); C.bit_op(e, '<<'); C.push_x6(e)
+    C.load_const(e, 1); C.push_x6(e); C.load_const(e, 0)
+    C.pop_to(e, "x5"); C.bit_op(e, '<<')
+    C.pop_to(e, "x5"); C.bit_op(e, '|'); e.emit("    ecall 0x000")   # 9
+    C.load_const(e, 0xFF); C.push_x6(e); C.load_const(e, 0x0F)
+    C.pop_to(e, "x5"); C.bit_op(e, '&'); e.emit("    ecall 0x000")   # 15
+    C.load_const(e, 0xF0); C.push_x6(e); C.load_const(e, 0xFF)
+    C.pop_to(e, "x5"); C.bit_op(e, '^'); e.emit("    ecall 0x000")   # 15
+    C.load_const(e, 0); C.bit_not(e); e.emit("    ecall 0x000")      # -1
+    C.func_epilogue(e)
+    assert run(e.text()) == [('int',9),('int',15),('int',15),('int',-1)]
+
+def t_struct():
+    # struct at 0x9100: write fields (incl. out-of-range offset), read back
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_abs_addr(e, 0x9100, "x4")
+    C.load_const(e, 17);  C.store_word_at(e, "x4", 0, "x6")   # field@0
+    C.load_const(e, 51);  C.store_word_at(e, "x4", 4, "x6")   # field@4
+    C.load_const(e, 92);  C.store_word_at(e, "x4", 200, "x6") # field@200 (far)
+    C.load_word_at(e, "x4", 0, "x6");   e.emit("    ecall 0x000")
+    C.load_word_at(e, "x4", 4, "x6");   e.emit("    ecall 0x000")
+    C.load_word_at(e, "x4", 200, "x6"); e.emit("    ecall 0x000")
+    C.func_epilogue(e)
+    assert run(e.text()) == [('int',17),('int',51),('int',92)]
+
+def t_unsigned_cmp():
+    # 0xF000 vs 0x0010: unsigned, 0xF000 > 0x0010 (signed it'd be negative<positive)
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 0)
+    C.load_const(e, 0xF000); C.push_x6(e); C.load_const(e, 0x0010)
+    C.pop_to(e, "x5"); C.cmp_unsigned(e, '>'); e.emit("    ecall 0x000")  # 1
+    C.func_epilogue(e)
+    assert run(e.text()) == [('int',1)]
+
+def t_break_nested():
+    # nested loops; inner break must exit inner only -> sum = 0+1+2 = 3
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 3)
+    C.load_const(e,0); C.store_local(e,0)
+    C.load_const(e,1); C.store_local(e,1)
+    def oc(e):
+        C.load_local(e,1); C.push_x6(e); C.load_const(e,3); C.pop_to(e,"x5"); C.bin_op(e,'<=',True)
+    def ob(e):
+        C.load_const(e,1); C.store_local(e,2)
+        def ic(e):
+            C.load_local(e,2); C.push_x6(e); C.load_const(e,100); C.pop_to(e,"x5"); C.bin_op(e,'<=',True)
+        def ib(e):
+            def c(e):
+                C.load_local(e,2); C.push_x6(e); C.load_local(e,1); C.pop_to(e,"x5"); C.bin_op(e,'==',True)
+            C.if_then_else(e, c, lambda e: C.emit_break(e), None)
+            C.load_local(e,0); C.push_x6(e); C.load_const(e,1); C.pop_to(e,"x5"); C.bin_op(e,'+',True); C.store_local(e,0)
+            C.load_local(e,2); C.push_x6(e); C.load_const(e,1); C.pop_to(e,"x5"); C.bin_op(e,'+',True); C.store_local(e,2)
+        C.while_loop(e, ic, ib)
+        C.load_local(e,1); C.push_x6(e); C.load_const(e,1); C.pop_to(e,"x5"); C.bin_op(e,'+',True); C.store_local(e,1)
+    C.while_loop(e, oc, ob)
+    C.load_local(e,0); e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int',3)]
+
+def t_continue():
+    # count odds in 1..10 via continue -> 5
+    e = C.Emitter(); C.crt0(e); C.runtime(e)
+    C.func_prologue(e, "main", 2)
+    C.load_const(e,0); C.store_local(e,0)
+    C.load_const(e,0); C.store_local(e,1)
+    def cond(e):
+        C.load_local(e,1); C.push_x6(e); C.load_const(e,10); C.pop_to(e,"x5"); C.bin_op(e,'<',True)
+    def body(e):
+        C.load_local(e,1); C.push_x6(e); C.load_const(e,1); C.pop_to(e,"x5"); C.bin_op(e,'+',True); C.store_local(e,1)
+        def c(e):
+            C.load_local(e,1); C.push_x6(e); C.load_const(e,2); C.pop_to(e,"x5"); C.bin_op(e,'%',True)
+            C.push_x6(e); C.load_const(e,0); C.pop_to(e,"x5"); C.bin_op(e,'==',True)
+        C.if_then_else(e, c, lambda e: C.emit_continue(e), None)
+        C.load_local(e,0); C.push_x6(e); C.load_const(e,1); C.pop_to(e,"x5"); C.bin_op(e,'+',True); C.store_local(e,0)
+    C.while_loop(e, cond, body)
+    C.load_local(e,0); e.emit("    ecall 0x000"); C.func_epilogue(e)
+    assert run(e.text()) == [('int',5)]
+
+if __name__ == '__main__':
+    tests = [t_arith, t_divmod, t_recursion, t_while, t_ifelse, t_bigconst,
+             t_bitwise, t_struct, t_unsigned_cmp, t_break_nested, t_continue]
+    passed = 0
+    for t in tests:
+        try:
+            t(); print(f"PASS {t.__name__}"); passed += 1
+        except AssertionError as ex:
+            print(f"FAIL {t.__name__}: {ex}")
+        except Exception as ex:
+            print(f"ERROR {t.__name__}: {ex}")
+    print(f"\n{passed}/{len(tests)} patterns validated")

--- a/compiler/zcc.py
+++ b/compiler/zcc.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+zcc — a compiler for ZC-embedded, targeting ZX16 assembly.
+
+Pipeline:  source text -> lexer -> tokens -> parser -> AST -> codegen -> asm
+
+Written in Python now, structured so it ports to ZC itself later (the AST is a flat
+node table addressed by integer handles, mirroring how the self-hosted version will
+use struct pointers / array indices).
+
+This file is built and tested incrementally. Stage 1: lexer.
+"""
+
+# ---------------------------------------------------------------------------
+# Tokens
+# ---------------------------------------------------------------------------
+
+# token kinds (strings for readability; in ZC these become int constants)
+T_EOF='eof'; T_ID='id'; T_INT='int'; T_CHAR='char'; T_STR='str'
+T_KW='kw'; T_PUNCT='punct'
+
+KEYWORDS = {
+    'int','char','unsigned','void','struct','if','else','while',
+    'break','continue','return','sizeof','volatile','asm',
+}
+
+# multi-char punctuators, longest first so the scanner is greedy
+PUNCT3 = []  # none in ZC
+PUNCT2 = ['==','!=','<=','>=','<<','>>','->']
+PUNCT1 = list('+-*/%&|^~<>=(){}[];,.!')
+
+class Token:
+    __slots__=('kind','val','line')
+    def __init__(self,kind,val,line):
+        self.kind=kind; self.val=val; self.line=line
+    def __repr__(self):
+        return f"{self.kind}:{self.val!r}@{self.line}"
+
+class LexError(Exception): pass
+
+def is_id_start(c): return c.isalpha() or c=='_'
+def is_id_char(c):  return c.isalnum() or c=='_'
+
+def lex(src):
+    toks=[]; i=0; n=len(src); line=1
+    def err(msg): raise LexError(f"line {line}: {msg}")
+    while i<n:
+        c=src[i]
+        # whitespace
+        if c=='\n': line+=1; i+=1; continue
+        if c in ' \t\r': i+=1; continue
+        # line comments
+        if c=='/' and i+1<n and src[i+1]=='/':
+            while i<n and src[i]!='\n': i+=1
+            continue
+        # identifiers / keywords
+        if is_id_start(c):
+            j=i+1
+            while j<n and is_id_char(src[j]): j+=1
+            word=src[i:j]
+            toks.append(Token(T_KW if word in KEYWORDS else T_ID, word, line))
+            i=j; continue
+        # numbers (decimal + hex)
+        if c.isdigit():
+            j=i
+            if c=='0' and i+1<n and src[i+1] in 'xX':
+                j=i+2
+                while j<n and src[j] in '0123456789abcdefABCDEF': j+=1
+                val=int(src[i:j],16)
+            else:
+                while j<n and src[j].isdigit(): j+=1
+                val=int(src[i:j],10)
+            toks.append(Token(T_INT,val,line)); i=j; continue
+        # char literal
+        if c=="'":
+            i+=1
+            if i>=n: err("unterminated char literal")
+            if src[i]=='\\':
+                i+=1
+                esc={'n':10,'t':9,'r':13,'0':0,'\\':92,"'":39}
+                if src[i] not in esc: err(f"bad escape \\{src[i]}")
+                val=esc[src[i]]; i+=1
+            else:
+                val=ord(src[i]); i+=1
+            if i>=n or src[i]!="'": err("unterminated char literal")
+            i+=1
+            toks.append(Token(T_CHAR,val,line)); continue
+        # string literal
+        if c=='"':
+            i+=1; buf=[]
+            while i<n and src[i]!='"':
+                if src[i]=='\\':
+                    i+=1
+                    esc={'n':'\n','t':'\t','r':'\r','0':'\0','\\':'\\','"':'"'}
+                    if src[i] not in esc: err(f"bad escape \\{src[i]}")
+                    buf.append(esc[src[i]]); i+=1
+                else:
+                    if src[i]=='\n': err("newline in string")
+                    buf.append(src[i]); i+=1
+            if i>=n: err("unterminated string")
+            i+=1
+            toks.append(Token(T_STR,''.join(buf),line)); continue
+        # punctuators (greedy: try 2-char then 1-char)
+        two=src[i:i+2]
+        if two in PUNCT2:
+            toks.append(Token(T_PUNCT,two,line)); i+=2; continue
+        if c in PUNCT1:
+            toks.append(Token(T_PUNCT,c,line)); i+=1; continue
+        err(f"unexpected character {c!r}")
+    toks.append(Token(T_EOF,None,line))
+    return toks
+
+
+# ---------------------------------------------------------------------------
+# AST  — flat node table. Each node is a dict {'op':..., ...children as indices}.
+# Using integer handles (not nested objects) mirrors the self-hosted ZC version,
+# which will store nodes in arrays and reference them by index.
+# ---------------------------------------------------------------------------
+
+class ParseError(Exception): pass
+
+class Parser:
+    def __init__(self, toks):
+        self.toks=toks; self.p=0
+        self.nodes=[]            # node table
+        self.structs={}          # tag -> {'fields':[(name,type,off)], 'size':n}
+        self.funcs=[]            # list of function node indices
+        self.globals=[]          # list of (name, type, init) 
+
+    # ---- node allocation ----
+    def node(self, **kw):
+        self.nodes.append(kw); return len(self.nodes)-1
+
+    # ---- token helpers ----
+    def cur(self): return self.toks[self.p]
+    def at_end(self): return self.cur().kind==T_EOF
+    def advance(self): t=self.toks[self.p]; self.p+=1; return t
+    def is_punct(self,s): t=self.cur(); return t.kind==T_PUNCT and t.val==s
+    def is_kw(self,s): t=self.cur(); return t.kind==T_KW and t.val==s
+    def eat_punct(self,s):
+        if not self.is_punct(s):
+            self.err(f"expected '{s}'")
+        return self.advance()
+    def eat_kw(self,s):
+        if not self.is_kw(s): self.err(f"expected '{s}'")
+        return self.advance()
+    def err(self,msg):
+        t=self.cur(); raise ParseError(f"line {t.line}: {msg}, got {t.kind}:{t.val!r}")
+
+    # ---- types ----
+    # A type is represented as a dict: {'base':'int'|'char'|'unsigned'|'uchar'|'void'|('struct',tag),
+    #                                   'ptr':N}  where ptr = pointer depth
+    def parse_type(self):
+        if self.is_kw('volatile'): self.advance()  # accepted, ignored
+        if self.is_kw('unsigned'):
+            self.advance()
+            if self.is_kw('char'): self.advance(); base='uchar'
+            else:
+                if self.is_kw('int'): self.advance()
+                base='unsigned'
+        elif self.is_kw('int'): self.advance(); base='int'
+        elif self.is_kw('char'): self.advance(); base='char'
+        elif self.is_kw('void'): self.advance(); base='void'
+        elif self.is_kw('struct'):
+            self.advance()
+            if self.cur().kind!=T_ID: self.err("expected struct tag")
+            tag=self.advance().val
+            base=('struct',tag)
+        else:
+            return None
+        ptr=0
+        while self.is_punct('*'): self.advance(); ptr+=1
+        return {'base':base,'ptr':ptr}
+
+    def looks_like_type(self):
+        t=self.cur()
+        return t.kind==T_KW and t.val in ('int','char','unsigned','void','struct','volatile')
+
+    # ---- top level ----
+    def parse_program(self):
+        while not self.at_end():
+            if self.is_kw('struct') and self.toks[self.p+2].kind==T_PUNCT and self.toks[self.p+2].val=='{':
+                self.parse_struct_decl()
+                continue
+            self.parse_toplevel_decl()
+        return self
+
+    def parse_struct_decl(self):
+        self.eat_kw('struct')
+        tag=self.advance().val
+        self.eat_punct('{')
+        fields=[]; off=0
+        while not self.is_punct('}'):
+            ftype=self.parse_type()
+            if ftype is None: self.err("expected field type")
+            fname=self.advance().val
+            arrlen=None
+            if self.is_punct('['):
+                self.advance(); arrlen=self.advance().val; self.eat_punct(']')
+            self.eat_punct(';')
+            sz=self.type_size(ftype) if arrlen is None else self.type_size(ftype)*arrlen
+            # alignment: word-sized members on even offset
+            if self.type_align(ftype)==2 and (off & 1): off+=1
+            fields.append((fname,ftype,off,arrlen))
+            off+=sz
+        self.eat_punct('}'); self.eat_punct(';')
+        if off & 1: off+=1   # pad struct to even size
+        self.structs[tag]={'fields':fields,'size':off}
+
+    def type_size(self,t):
+        if t['ptr']>0: return 2
+        b=t['base']
+        if b in ('int','unsigned'): return 2
+        if b in ('char','uchar'): return 1
+        if isinstance(b,tuple) and b[0]=='struct':
+            return self.structs[b[1]]['size']
+        if b=='void': return 0
+        self.err(f"unknown type size {b}")
+    def type_align(self,t):
+        if t['ptr']>0: return 2
+        b=t['base']
+        if b in ('char','uchar'): return 1
+        return 2
+
+    def parse_toplevel_decl(self):
+        ty=self.parse_type()
+        if ty is None: self.err("expected declaration")
+        name=self.advance().val
+        if self.is_punct('('):
+            self.parse_function(ty,name)
+        else:
+            # global variable
+            arrlen=None
+            if self.is_punct('['):
+                self.advance(); arrlen=self.advance().val; self.eat_punct(']')
+            init=None
+            if self.is_punct('='):
+                self.advance(); init=self.advance().val  # constant scalar only
+            self.eat_punct(';')
+            self.globals.append((name,ty,arrlen,init))
+
+    def parse_function(self,ret,name):
+        self.eat_punct('(')
+        params=[]
+        if self.is_kw('void') and self.toks[self.p+1].kind==T_PUNCT and self.toks[self.p+1].val==')':
+            self.advance()
+        else:
+            while not self.is_punct(')'):
+                pty=self.parse_type()
+                pname=self.advance().val
+                params.append((pname,pty))
+                if self.is_punct(','): self.advance()
+                else: break
+        self.eat_punct(')')
+        body=self.parse_block()
+        idx=self.node(op='func',name=name,ret=ret,params=params,body=body)
+        self.funcs.append(idx)
+
+    # ---- statements ----
+    def parse_block(self):
+        self.eat_punct('{')
+        stmts=[]
+        while not self.is_punct('}'):
+            stmts.append(self.parse_stmt())
+        self.eat_punct('}')
+        return self.node(op='block',stmts=stmts)
+
+    def parse_stmt(self):
+        if self.is_punct('{'): return self.parse_block()
+        if self.is_kw('if'):
+            self.advance(); self.eat_punct('(')
+            cond=self.parse_expr(); self.eat_punct(')')
+            then=self.parse_stmt()
+            els=None
+            if self.is_kw('else'): self.advance(); els=self.parse_stmt()
+            return self.node(op='if',cond=cond,then=then,els=els)
+        if self.is_kw('while'):
+            self.advance(); self.eat_punct('(')
+            cond=self.parse_expr(); self.eat_punct(')')
+            body=self.parse_stmt()
+            return self.node(op='while',cond=cond,body=body)
+        if self.is_kw('return'):
+            self.advance()
+            val=None
+            if not self.is_punct(';'): val=self.parse_expr()
+            self.eat_punct(';')
+            return self.node(op='return',val=val)
+        if self.is_kw('break'):
+            self.advance(); self.eat_punct(';'); return self.node(op='break')
+        if self.is_kw('continue'):
+            self.advance(); self.eat_punct(';'); return self.node(op='continue')
+        if self.is_kw('asm'):
+            self.advance(); self.eat_punct('(')
+            s=self.advance().val; self.eat_punct(')'); self.eat_punct(';')
+            return self.node(op='asm',text=s)
+        if self.looks_like_type():
+            ty=self.parse_type()
+            name=self.advance().val
+            arrlen=None
+            if self.is_punct('['):
+                self.advance(); arrlen=self.advance().val; self.eat_punct(']')
+            init=None
+            if self.is_punct('='):
+                self.advance(); init=self.parse_expr()
+            self.eat_punct(';')
+            return self.node(op='vardecl',name=name,vtype=ty,arrlen=arrlen,init=init)
+        # expression statement
+        e=self.parse_expr(); self.eat_punct(';')
+        return self.node(op='exprstmt',expr=e)
+
+    # ---- expressions (precedence climbing per SPEC) ----
+    def parse_expr(self): return self.parse_assign()
+
+    def parse_assign(self):
+        left=self.parse_equality()
+        if self.is_punct('='):
+            self.advance()
+            right=self.parse_assign()
+            return self.node(op='assign',lhs=left,rhs=right)
+        return left
+
+    def _binlevel(self, sub, ops):
+        left=sub()
+        while self.cur().kind==T_PUNCT and self.cur().val in ops:
+            op=self.advance().val
+            right=sub()
+            left=self.node(op='binop',bop=op,lhs=left,rhs=right)
+        return left
+
+    def parse_equality(self): return self._binlevel(self.parse_relational, ('==','!='))
+    def parse_relational(self): return self._binlevel(self.parse_bor, ('<','<=','>','>='))
+    def parse_bor(self): return self._binlevel(self.parse_bxor, ('|',))
+    def parse_bxor(self): return self._binlevel(self.parse_band, ('^',))
+    def parse_band(self): return self._binlevel(self.parse_shift, ('&',))
+    def parse_shift(self): return self._binlevel(self.parse_add, ('<<','>>'))
+    def parse_add(self): return self._binlevel(self.parse_mul, ('+','-'))
+    def parse_mul(self): return self._binlevel(self.parse_unary, ('*','/','%'))
+
+    def parse_unary(self):
+        if self.cur().kind==T_PUNCT and self.cur().val in ('-','~','*','&'):
+            op=self.advance().val
+            operand=self.parse_unary()
+            return self.node(op='unop',uop=op,operand=operand)
+        # cast:  ( type ) unary
+        if self.is_punct('(') and self._next_is_type():
+            self.advance()
+            ty=self.parse_type()
+            self.eat_punct(')')
+            operand=self.parse_unary()
+            return self.node(op='cast',ctype=ty,operand=operand)
+        return self.parse_postfix()
+
+    def _next_is_type(self):
+        t=self.toks[self.p+1]   # token after the '('
+        return t.kind==T_KW and t.val in ('int','char','unsigned','void','struct','volatile')
+
+    def parse_postfix(self):
+        e=self.parse_primary()
+        while True:
+            if self.is_punct('['):
+                self.advance(); idx=self.parse_expr(); self.eat_punct(']')
+                e=self.node(op='index',base=e,idx=idx)
+            elif self.is_punct('('):
+                self.advance(); args=[]
+                while not self.is_punct(')'):
+                    args.append(self.parse_expr())
+                    if self.is_punct(','): self.advance()
+                    else: break
+                self.eat_punct(')')
+                e=self.node(op='call',fn=e,args=args)
+            elif self.is_punct('.'):
+                self.advance(); field=self.advance().val
+                e=self.node(op='member',base=e,field=field,arrow=False)
+            elif self.is_punct('->'):
+                self.advance(); field=self.advance().val
+                e=self.node(op='member',base=e,field=field,arrow=True)
+            else:
+                break
+        return e
+
+    def parse_primary(self):
+        t=self.cur()
+        if self.is_punct('('):
+            self.advance(); e=self.parse_expr(); self.eat_punct(')'); return e
+        if t.kind==T_INT: self.advance(); return self.node(op='intlit',val=t.val)
+        if t.kind==T_CHAR: self.advance(); return self.node(op='charlit',val=t.val)
+        if t.kind==T_STR: self.advance(); return self.node(op='strlit',val=t.val)
+        if t.kind==T_ID: self.advance(); return self.node(op='ident',name=t.val)
+        self.err("expected expression")
+
+
+def parse(src):
+    return Parser(lex(src)).parse_program()
+
+
+def dump_ast(p, idx, ind=0):
+    n=p.nodes[idx]; pad='  '*ind
+    op=n['op']
+    if op=='func':
+        print(f"{pad}func {n['name']} params={[x[0] for x in n['params']]}")
+        dump_ast(p,n['body'],ind+1)
+    elif op=='block':
+        print(f"{pad}block")
+        for s in n['stmts']: dump_ast(p,s,ind+1)
+    elif op=='if':
+        print(f"{pad}if"); dump_ast(p,n['cond'],ind+1); dump_ast(p,n['then'],ind+1)
+        if n['els'] is not None: print(f"{pad}else"); dump_ast(p,n['els'],ind+1)
+    elif op=='while':
+        print(f"{pad}while"); dump_ast(p,n['cond'],ind+1); dump_ast(p,n['body'],ind+1)
+    elif op=='return':
+        print(f"{pad}return"); 
+        if n['val'] is not None: dump_ast(p,n['val'],ind+1)
+    elif op in ('break','continue'):
+        print(f"{pad}{op}")
+    elif op=='vardecl':
+        print(f"{pad}vardecl {n['name']} : {n['vtype']} arr={n['arrlen']}")
+        if n['init'] is not None: dump_ast(p,n['init'],ind+1)
+    elif op=='exprstmt':
+        print(f"{pad}exprstmt"); dump_ast(p,n['expr'],ind+1)
+    elif op=='assign':
+        print(f"{pad}assign"); dump_ast(p,n['lhs'],ind+1); dump_ast(p,n['rhs'],ind+1)
+    elif op=='binop':
+        print(f"{pad}binop {n['bop']}"); dump_ast(p,n['lhs'],ind+1); dump_ast(p,n['rhs'],ind+1)
+    elif op=='unop':
+        print(f"{pad}unop {n['uop']}"); dump_ast(p,n['operand'],ind+1)
+    elif op=='cast':
+        print(f"{pad}cast {n['ctype']}"); dump_ast(p,n['operand'],ind+1)
+    elif op=='call':
+        print(f"{pad}call"); dump_ast(p,n['fn'],ind+1)
+        for a in n['args']: dump_ast(p,a,ind+1)
+    elif op=='index':
+        print(f"{pad}index"); dump_ast(p,n['base'],ind+1); dump_ast(p,n['idx'],ind+1)
+    elif op=='member':
+        print(f"{pad}member {'->' if n['arrow'] else '.'}{n['field']}"); dump_ast(p,n['base'],ind+1)
+    elif op=='intlit': print(f"{pad}int {n['val']}")
+    elif op=='charlit': print(f"{pad}char {n['val']}")
+    elif op=='strlit': print(f"{pad}str {n['val']!r}")
+    elif op=='ident': print(f"{pad}ident {n['name']}")
+    elif op=='asm': print(f"{pad}asm {n['text']!r}")
+    else: print(f"{pad}?{op}")
+
+
+if __name__=='__main__':
+    sample = r'''
+    int g = 0x1F;
+    struct Node { int kind; struct Node *next; };
+    int add(int a, int b) {
+        unsigned m;
+        m = a & 0xFF;
+        if (a < b) return b; else return a;
+        while (a != 0) { a = a - 1; if (a == 3) break; }
+        return m + (a << 2);
+    }
+    '''
+    p=parse(sample)
+    print("structs:", {k:(v['size'],[(f[0],f[2]) for f in v['fields']]) for k,v in p.structs.items()})
+    print("globals:", p.globals)
+    for f in p.funcs: dump_ast(p,f)
+

--- a/docs/README_corrected.md
+++ b/docs/README_corrected.md
@@ -1,0 +1,511 @@
+# ZX16 RISC ISA Specification
+
+## Overview
+The ZX16 RISC ISA is a 16-bit reduced-instruction-set architecture designed for simplicity, efficiency, and educational use. It features:
+- **16-bit fixed-width** instructions and data  
+- **8 general-purpose registers** (x0–x7) plus a 16-bit PC  
+- **64 KB flat address space** for code, data, MMIO, and interrupt vectors  
+- **8 instruction formats** selected by bits [2:0]  
+- **50+ real & pseudo-instructions** covering ALU, branches, loads/stores, jumps, upper-immediates, and syscalls  
+- **Smart immediates**: any immediate < 16 bits is sign-extended  
+- **PC-relative control flow**: all branches, J and JAL use PC-relative offsets  
+- **Memory-mapped I/O** at 0xF000–0xFFFF  
+- **16 interrupt vectors** at 0x0000–0x001F (2 bytes each; reset at 0x0000)
+
+---
+
+## Key Features
+- Compact 16-bit instructions  
+- Two-operand ALU (rd/rs1 is both destination & first source)  
+- Smart assembler handles large constants via pseudo-ops  
+- Rich syscall interface for I/O, graphics, audio  
+- Little-endian byte order
+- Aligned memory access required for word operations
+- Byte-addressable memory
+
+---
+
+## Register Architecture
+
+### General-Purpose Registers
+
+| Register | ABI | Role                    | Notes                       |
+|:--------:|:---:|:-----------------------:|:----------------------------|
+| x0       | t0  | Temporary               | Caller-saved scratch/Assembler Temporary        |
+| x1       | ra  | Return address          | Used by JAL/JALR            |
+| x2       | sp  | Stack pointer           | Initialized to 0xF000       |
+| x3       | s0  | Saved / Frame pointer   | Callee-saved                |
+| x4       | s1  | Saved                   | Callee-saved                |
+| x5       | t1  | Temporary               | Caller-saved scratch        |
+| x6       | a0  | Arg0 / Return value     |                             |
+| x7       | a1  | Arg1                    | Further args spill to stack |
+
+### Special Registers
+- **PC**: 16-bit program counter  
+
+### Reset Behavior
+- **PC**: Initialized to 0x0000 on reset
+- **x2 (sp)**: Initialized to 0xF000 on reset
+- **x0–x1, x3–x7**: Undefined values on reset (not initialized)
+
+> **On the SP reset value:** SP is initialized to 0xF000, the MMIO base — one word
+> *past* the top of usable RAM (0xEFFF). The stack is full-descending with
+> pre-decrement: `PUSH` does `ADDI sp, -2` then `SW rd, 0(sp)`, so the first push
+> writes to 0xEFFE–0xEFFF, the top word of RAM. SP is never dereferenced while it
+> holds 0xF000, so no MMIO access occurs from the initial value.
+
+> **Note for RISC-V users:** In ZX16, `x0` is a normal general-purpose register
+> (ABI name `t0`). It is **not** a hardwired-zero register. Writes to `x0` take
+> effect, and reads return whatever was last written. Idioms such as `CLR rd`
+> (which expands to `XOR rd, rd`) and `NOP` (`ADD x0, x0`) rely on this.
+
+---
+
+## Memory Map
+
+| Range         | Usage                                        |
+|:-------------:|:---------------------------------------------|
+| 0x0000–0x001F | Interrupt vector table (16 entries × 2 bytes)|
+| 0x0020–0xEFFF | RAM & ROM                                    |
+| 0xF000–0xFFFF | MMIO (I/O registers start at 0xF000)         |
+
+### Memory Properties
+- **Endianness**: Little-endian
+- **Addressing**: Byte-addressable
+- **Alignment**: Word accesses (SW/LW) must be aligned to even addresses
+- **Stack**: Grows downward; SP initialized to 0xF000, first push lands at 0xEFFE
+
+## Interrupt Vector Table
+- 16 fixed entries at 0x0000–0x001E (2 bytes each)  
+- Reset handler at 0x0000; others at 0x0002, 0x0004, …, 0x001E  
+
+---
+
+## Instruction Formats
+
+Every instruction is 16 bits, with bits [2:0] as primary opcode:
+
+| opcode ([2:0]) | Format    |
+|:--------------:|:----------|
+| 000            | R-Type    |
+| 001            | I-Type    |
+| 010            | B-Type    |
+| 011            | S-Type    |
+| 100            | L-Type    |
+| 101            | J-Type    |
+| 110            | U-Type    |
+| 111            | SYS-Type  |
+
+---
+
+## ZX16 Instruction Format Field Layouts
+
+All instructions are 16 bits. Bits [2:0] select the format/opcode.
+## Instruction Formats
+
+All instructions are 16 bits with bits [2:0] as primary opcode:
+
+### R-Type (opcode = `000`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│    funct4     │    rs2    │  rd/rs1   │   func3   │ 0 │ 0 │ 0 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15:12]** funct4  
+- **[11:9]** rs2  
+- **[8:6]** rd/rs1 (two‐operand: dest & first source)  
+- **[5:3]** func3  
+- **[2:0]** 000  
+
+### I-Type (opcode = `001`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│        imm7 (signed)      │  rd/rs1   │   func3   │ 0 │ 0 │ 1 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15:9]** imm7 (7-bit signed immediate, sign-extended)  
+- **[8:6]** rd/rs1  
+- **[5:3]** func3  
+- **[2:0]** 001  
+
+**Note**: For shift instructions: `shift_amt = imm7[3:0]}`; `imm7[6:4]` are used to determine the shift type.
+
+### B-Type (opcode = `010`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│   imm[4:1]    │    rs2    │   rs1     │   func3   │ 0 │ 1 │ 0 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15:12]** imm[4:1] (high 4 bits of 5-bit signed offset, imm[0] = 0) -- Range: -16 to 14.  
+- **[11:9]** rs2 (ignored for BZ/BNZ)  
+- **[8:6]** rs1  
+- **[5:3]** func3  
+- **[2:0]** 010  
+
+### S-Type (opcode = `011`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│   imm[3:0]    │    rs2    │   rs1     │   func3   │ 0 │ 1 │ 1 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15:12]** imm[3:0] (4-bit signed store offset) -- Range: -8 to +7 
+- **[11:9]** rs2 (data register)  
+- **[8:6]** rs1 (base register)  
+- **[5:3]** func3  
+- **[2:0]** 011  
+
+### L-Type (opcode = `100`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│   imm[3:0]    │    rs2    │    rd     │   func3   │ 1 │ 0 │ 0 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15:12]** imm[3:0] (4-bit signed load offset) -- Range: -8 to +7
+- **[11:9]** rs2 (base register)  
+- **[8:6]** rd (destination register)  
+- **[5:3]** func3  
+- **[2:0]** 100  
+
+### J-Type (opcode = `101`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│ L │         imm[9:4]      │    rd     │ imm[3:1]  │ 1 │ 0 │ 1 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+- **[15]** link flag (0 = J, 1 = JAL)  
+- **[14:9]** imm[9:4] (with imm[3:1] and imm[0]=0 the field spans offset bits [9:1], sign bit = bit 9) -- Range: -512 to +510 
+- **[8:6]** rd (link register for JAL)  
+- **[5:3]** imm[3:1] (low 3 bits of offset)  
+- **[2:0]** 101  
+
+### U-Type (opcode = `110`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│ F │   imm[15:10]      │    rd     │ imm[9:7]  │ 1 │ 1 │ 0 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+
+- **[15]** flag (0 = LUI, 1 = AUIPC)  
+- **[14:9]** imm[15:10] (high 6 bits of immediate)  
+- **[8:6]** rd  
+- **[5:3]** imm[9:7] (mid 3 bits of immediate)  
+- **[2:0]** 110  
+
+**Encoding note:** The assembler takes a 9-bit operand `v` (0–511) and the resulting
+register value is `v << 7`. The nine bits of `v` are scattered into the instruction
+as the immediate field shown above; equivalently, the immediate occupies result bits
+[15:7]. So `LUI rd, v` sets `rd = v << 7`, and `AUIPC rd, v` sets `rd = PC + (v << 7)`.
+
+### SYS-Type (opcode = `111`)
+```
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+│              svc[9:0]                 │ 0 │ 0 │ 0 │ 1 │ 1 │ 1 │
+└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+```
+
+- **[15:6]** svc (10-bit system-call number)  
+- **[5:3]** 000 (reserved, must be zero)  
+- **[2:0]** 111  
+
+Note: only `ECALL` uses this format; bits [5:3] are reserved and currently always
+zero. The full opcode that identifies SYS-Type is thus the 6-bit pattern `000111`.
+
+---
+
+## Instruction Set Reference
+
+### R-Type Instructions
+| Mnemonic | Description                               |
+|:--------:|:------------------------------------------|
+| **ADD**  | rd ← rd + rs2                             |
+| **SUB**  | rd ← rd – rs2                             |
+| **SLT**  | rd ← (rd < rs2) ? 1 : 0                   |
+| **SLTU** | rd ← (unsigned rd < unsigned rs2) ? 1 : 0 |
+| **SLL**  | rd ← rd << (rs2 & 0xF)                    |
+| **SRL**  | rd ← rd >> (rs2 & 0xF) (logical)          |
+| **SRA**  | rd ← rd >> (rs2 & 0xF) (arithmetic)       |
+| **OR**   | rd ← rd ∣ rs2                             |
+| **AND**  | rd ← rd ∧ rs2                             |
+| **XOR**  | rd ← rd ⊕ rs2                             |
+| **MV**   | rd ← rs2                                  |
+| **JR**   | PC ← rd                                   |
+| **JALR** | rd ← PC + 2; PC ← rs2                     |
+
+### I-Type Instructions
+| Mnemonic  | Description                                     |
+|:---------:|:------------------------------------------------|
+| **ADDI**  | rd ← rd + sext(imm7)                            |
+| **SLTI**  | rd ← (rd < sext(imm7)) ? 1 : 0                  |
+| **SLTUI** | rd ← (unsigned rd < unsigned sext(imm7)) ? 1 : 0|
+| **SLLI**  | rd ← rd << imm[3:0]                             |
+| **SRLI**  | rd ← rd >> imm[3:0] (logical)                   |
+| **SRAI**  | rd ← rd >> imm[3:0] (arithmetic)                |
+| **ORI**   | rd ← rd ∣ sext(imm7)                            |
+| **ANDI**  | rd ← rd ∧ sext(imm7)                            |
+| **XORI**  | rd ← rd ⊕ sext(imm7)                            |
+| **LI**    | rd ← sext(imm7)                                 |
+
+### B-Type Instructions
+| Mnemonic | Description                                          |
+|:--------:|:-----------------------------------------------------|
+| **BEQ**  | PC ← PC + offset if x[rs1] == x[rs2]                 |
+| **BNE**  | PC ← PC + offset if x[rs1] != x[rs2]                 |
+| **BZ**   | PC ← PC + offset if x[rs1] == 0                     |
+| **BNZ**  | PC ← PC + offset if x[rs1] != 0                     |
+| **BLT**  | PC ← PC + offset if x[rs1] < x[rs2]                  |
+| **BGE**  | PC ← PC + offset if x[rs1] ≥ x[rs2]                  |
+| **BLTU** | PC ← PC + offset if unsigned x[rs1] < unsigned x[rs2]|
+| **BGEU** | PC ← PC + offset if unsigned x[rs1] ≥ unsigned x[rs2]|
+
+### S-Type Instructions
+| Mnemonic | Description                                                      |
+|:--------:|:-----------------------------------------------------------------|
+| **SB**   | Mem[x[rs1] + sext(imm4)] ← least-significant byte of x[rs2]     |
+| **SW**   | Mem[x[rs1] + sext(imm4)] ← x[rs2] (16 bits)                     |
+
+### L-Type Instructions
+| Mnemonic | Description                                                   |
+|:--------:|:--------------------------------------------------------------|
+| **LB**   | rd ← sign-extended byte at Mem[x[rs2] + sext(imm4)]          |
+| **LW**   | rd ← word at Mem[x[rs2] + sext(imm4)] (16 bits)              |
+| **LBU**  | rd ← zero-extended byte at Mem[x[rs2] + sext(imm4)]          |
+
+### J-Type Instructions
+| Mnemonic | Description                           |
+|:--------:|:--------------------------------------|
+| **J**    | PC ← PC + offset                      |
+| **JAL**  | x[rd] ← PC + 2; PC ← PC + offset      |
+
+### U-Type Instructions
+| Mnemonic  | Description                      |
+|:---------:|:---------------------------------|
+| **LUI**   | rd ← (imm[15:7] << 7)            |
+| **AUIPC** | rd ← PC + (imm[15:7] << 7)       |
+
+### SYS-Type Instructions
+| Mnemonic | Description                              |
+|:--------:|:-----------------------------------------|
+| **ECALL**| Trap to service number in bits [15:6]   |
+
+---
+
+## Instruction Identification Table
+
+This table shows, for each instruction, the key fields used to distinguish it: the primary opcode (bits [2:0]), plus any `funct4`, `func3`, `link` or `flag` bits, or immediate‐pattern conditions.
+
+| Mnemonic | Format | opcode [2:0] | funct4 [15:12] | func3 [5:3] | link/flag (bit15)      | imm‐pattern/notes             |
+|:--------:|:------:|:------------:|:--------------:|:-----------:|:-----------------------:|:------------------------------|
+| **R-Type** |||||||
+| ADD      | R      | `000`        | `0000`         | `000`       | —                       | two‐operand                    |
+| SUB      | R      | `000`        | `0001`         | `000`       | —                       |                                |
+| SLT      | R      | `000`        | `0010`         | `001`       | —                       |                                |
+| SLTU     | R      | `000`        | `0011`         | `010`       | —                       |                                |
+| SLL      | R      | `000`        | `0100`         | `011`       | —                       | logical left shift            |
+| SRL      | R      | `000`        | `0101`         | `011`       | —                       | logical right shift           |
+| SRA      | R      | `000`        | `0110`         | `011`       | —                       | arithmetic right shift        |
+| OR       | R      | `000`        | `0111`         | `100`       | —                       |                                |
+| AND      | R      | `000`        | `1000`         | `101`       | —                       |                                |
+| XOR      | R      | `000`        | `1001`         | `110`       | —                       |                                |
+| MV       | R      | `000`        | `1010`         | `111`       | —                       | move                           |
+| JR       | R      | `000`        | `1011`         | `000`       | —                       | PC ← rd                        |
+| JALR     | R      | `000`        | `1100`         | `000`       | —                       | link in rd, then PC ← rs2     |
+| **I-Type** |||||||
+| ADDI     | I      | `001`        | —              | `000`       | —                       | imm7 signed                   |
+| SLTI     | I      | `001`        | —              | `001`       | —                       | imm7 signed                   |
+| SLTUI    | I      | `001`        | —              | `010`       | —                       | imm7 unsigned compare         |
+| SLLI     | I      | `001`        | —              | `011`       | —                       | shift left logical, imm7[6:4]=`001` |
+| SRLI     | I      | `001`        | —              | `011`       | —                       | shift right logical, imm7[6:4]=`010` |
+| SRAI     | I      | `001`        | —              | `011`       | —                       | shift right arithmetic, imm7[6:4]=`100` |
+| ORI      | I      | `001`        | —              | `100`       | —                       |                                |
+| ANDI     | I      | `001`        | —              | `101`       | —                       |                                |
+| XORI     | I      | `001`        | —              | `110`       | —                       |                                |
+| LI       | I      | `001`        | —              | `111`       | —                       | real when imm ∈ [-64,63]; otherwise assembles as LI16 (LUI+ORI) |
+| **B-Type** |||||||
+| BEQ      | B      | `010`        | —              | `000`       | —                       | offset = sext(imm[4:1]∥0)     |
+| BNE      | B      | `010`        | —              | `001`       | —                       |                                |
+| BZ       | B      | `010`        | —              | `010`       | —                       | ignore rs2                    |
+| BNZ      | B      | `010`        | —              | `011`       | —                       | ignore rs2                    |
+| BLT      | B      | `010`        | —              | `100`       | —                       |                                |
+| BGE      | B      | `010`        | —              | `101`       | —                       |                                |
+| BLTU     | B      | `010`        | —              | `110`       | —                       | unsigned compare              |
+| BGEU     | B      | `010`        | —              | `111`       | —                       | unsigned compare              |
+| **S-Type** |||||||
+| SB       | S      | `011`        | —              | `000`       | —                       | store byte, offset=sext(imm[3:0]) |
+| SW       | S      | `011`        | —              | `001`       | —                       | store word                    |
+| **L-Type** |||||||
+| LB       | L      | `100`        | —              | `000`       | —                       | load byte                     |
+| LW       | L      | `100`        | —              | `001`       | —                       | load word                     |
+| LBU      | L      | `100`        | —              | `100`       | —                       | load byte unsigned            |
+| **J-Type** |||||||
+| J        | J      | `101`        | —              | —           | link=0                  | offset = sext({imm[9:4],imm[3:1],0}) |
+| JAL      | J      | `101`        | —              | —           | link=1                  | link in rd, then PC-relative  |
+| **U-Type** |||||||
+| LUI      | U      | `110`        | —              | —           | flag=0                  | imm from bits [15:7]<<7      |
+| AUIPC    | U      | `110`        | —              | —           | flag=1                  | PC + (imm<<7)                |
+| **SYS-Type** |||||||
+| ECALL    | SYS    | `111`        | —              | —           | —                       | trap to service number [15:6] |
+
+---
+
+## Pseudo-Instructions
+
+ZX16 supports several pseudo-instructions that expand to one or more real instructions:
+
+### **LI16 rd, imm16** - Load 16-bit immediate
+```
+LI16 x1, 0x1234
+```
+Expands to:
+```assembly
+LUI  x1, 0x24      # Load upper 9 bits into bits [15:7]  (0x1234 >> 7 = 0x24)
+ORI  x1, 0x34      # OR in the lower 7 bits             (0x1234 & 0x7F = 0x34)
+```
+The lower bits are combined with `ORI`, not `ADDI`. Because `LUI` clears the low 7
+bits of the destination, OR-ing the 7-bit remainder reconstructs the full value
+exactly, with no sign-extension to correct for. Any `imm16` in 0x0000–0xFFFF works
+with this two-instruction sequence.
+
+### **LA rd, label** - Load address (PC-relative)
+```assembly
+LA x1, data_label
+# Expands to:
+AUIPC x1, high     # high = ((label - PC) - low) >> 7   (9-bit field)
+ADDI  x1, low      # low  = (label - PC) sign-reduced to [-64, 63]
+```
+The offset `label - PC` is split so that the low part is a 7-bit *signed* value in
+[-64, 63] and the high part carries the remainder. `ADDI` is correct here (unlike in
+`LI16`) because the offset is computed as a signed quantity and the low part is
+deliberately reduced into signed range before the high part is adjusted.
+
+### **PUSH rd** - Push register to stack
+```assembly
+PUSH x1
+# Expands to:
+ADDI x2, -2        # SP -= 2 (decrement stack pointer)
+SW   x1, 0(x2)     # Store register at new SP
+```
+
+### **POP rd** - Pop from stack to register
+```assembly
+POP x1
+# Expands to:
+LW   x1, 0(x2)     # Load from current SP
+ADDI x2, 2         # SP += 2 (increment stack pointer)
+```
+
+### **CALL label** - Call function
+```assembly
+CALL func_name
+# Expands to:
+JAL x1, offset     # Jump and link (return address in x1/ra)
+```
+
+### **RET** - Return from function
+```assembly
+RET
+# Expands to:
+JR x1              # Jump to return address (x1/ra)
+```
+
+### **INC rd** - Increment register
+```assembly
+INC x1
+# Expands to:
+ADDI x1, 1         # rd = rd + 1
+```
+
+### **DEC rd** - Decrement register
+```assembly
+DEC x1
+# Expands to:
+ADDI x1, -1        # rd = rd - 1
+```
+
+### **NEG rd** - Negate register (two's complement)
+```assembly
+NEG x1
+# Expands to:
+XORI x1, -1        # Invert all bits (imm7 = -1 sign-extends to 0xFFFF)
+ADDI x1, 1         # Add 1 to complete two's complement
+```
+
+### **NOT rd** - Bitwise NOT
+```assembly
+NOT x1
+# Expands to:
+XORI x1, -1        # XOR with 0xFFFF (imm7 = -1 sign-extended)
+```
+
+### **CLR rd** - Clear register to zero
+```assembly
+CLR x1
+# Expands to:
+XOR x1, x1         # x1 = x1 XOR x1 = 0
+```
+
+### **NOP** - No operation
+```assembly
+NOP
+# Expands to:
+ADD x0, x0         # x0 = x0 + x0; result discarded into x0, no architectural effect of interest
+```
+
+---
+
+## Calling Convention
+
+### Function Calls
+- **Arguments**: x6 (a0), x7 (a1); additional arguments spill to stack
+- **Return value**: x6 (a0)
+- **Return address**: x1 (ra) - set by JAL/JALR, used by RET
+- **Stack pointer**: x2 (sp) - points to the last pushed word (full-descending)
+
+### Register Usage
+- **Caller-saved**: x0 (t0), x5 (t1), x6 (a0), x7 (a1)
+- **Callee-saved**: x3 (s0), x4 (s1)
+- **Special**: x1 (ra), x2 (sp)
+
+### Stack Management
+- Stack grows downward (toward lower addresses)
+- SP is reset to 0xF000; the first push lands at 0xEFFE–0xEFFF
+- Keep SP even (word-aligned), since SW/LW require aligned addresses
+- Callee must restore stack pointer before returning
+
+---
+
+## Implementation Notes
+
+### Immediate Ranges
+- **I-Type**: -64 to +63 (7-bit signed)
+- **S-Type/L-Type**: -8 to +7 (4-bit signed)
+- **B-Type**: -16 to +14 bytes (5-bit signed, word-aligned)
+- **J-Type**: -512 to +510 bytes (offset = sext of bits [9:1], sign bit = bit 9, word-aligned)
+- **U-Type**: 0 to 511 (9-bit unsigned immediate 0-511, shifted left 7 bits) 
+
+### Shift Operations
+- **Shift amount**: Limited to 0-15 (4 bits)
+- **R-Type shifts**: Use `rs2 & 0xF` as shift amount
+- **I-Type shifts**: Use `imm[3:0]` as shift amount, `imm[6:4]` selects operation
+
+### Memory Access
+- **Byte operations**: SB, LB, LBU - no alignment required
+- **Word operations**: SW, LW - must be aligned to even addresses
+- **Endianness**: Little-endian (LSB at lower address)
+
+### Control Flow
+- **Branches**: PC-relative, word-aligned targets
+- **Jumps**: PC-relative, word-aligned targets  
+- **Register jumps**: JR, JALR - absolute addressing
+
+---
+
+## Contribution
+Please refer to the contribution guide [here](docs/contribute.md).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,174 @@
+# ZC — a self-hosting C subset for ZX16 (embedded profile)
+
+ZC is a small subset of C designed for two goals at once:
+
+1. **Self-hosting** — the ZC compiler can be written in ZC and compile itself.
+2. **Bare-metal embedded use** — direct hardware access, bit manipulation, and
+   unsigned address arithmetic on ZX16.
+
+These goals reinforce each other: every feature added for embedded work (bytes,
+unsigned, bitwise ops, structs) is also useful in the compiler's own source, so the
+subset stays closed under "what it takes to compile itself."
+
+The guiding rule: **ZC contains what the compiler needs plus what bare-metal ZX16
+code needs — and nothing else.** Convenience features with easy rewrites are out.
+
+---
+
+## Types
+
+| Type            | Size | Notes |
+|-----------------|------|-------|
+| `int`           | 2 bytes, signed   | the native word |
+| `unsigned`      | 2 bytes, unsigned | addresses, masks, register values |
+| `char`          | 1 byte, signed    | bytes, MMIO registers, string chars |
+| `unsigned char` | 1 byte, unsigned  | raw byte values 0..255 |
+| `T *`           | 2 bytes           | pointer to any type |
+| `T[N]`          | N x sizeof(T)     | array, decays to pointer in expressions |
+| `struct Tag`    | sum of members (aligned) | records; see Structs |
+
+- `void` allowed only as a function return type.
+- No `long`, `short`, `float`, `double`, `union`, `enum`, `typedef`.
+- Signedness matters for: comparisons (`slt` vs `sltu`), right shift (`sra` vs
+  `srl`), and `char` load (`lb` vs `lbu`). The compiler tracks it per expression.
+
+## Structs
+
+```c
+struct Point { int x; int y; };
+struct Dev   { char status; char ctrl; int count; char buf[16]; };
+struct Node  { int kind; struct Node *next; };
+```
+
+- Members laid out in declaration order. `int`/`unsigned`/pointer members are
+  2-byte aligned (the compiler inserts padding before them when needed, since ZX16
+  `lw`/`sw` require even addresses); `char` members are byte-aligned.
+- Access: `s.field` and `p->field`. Field offset is a compile-time constant; codegen
+  emits `base + offset` then a load/store. (Offsets beyond the +-7 instruction range
+  are materialized into a register automatically.)
+- **Structs are used through pointers.** Passing/returning a struct *by value* is not
+  supported in v1; pass `struct T *`. This matches both embedded register-block usage
+  and the compiler's AST/symbol nodes.
+- Self-referential structs are allowed via pointer members.
+
+## Declarations
+
+```c
+int x;                 unsigned mask;
+char *p;               int a[100];
+struct Node *head;
+int g = 5;             // global, constant scalar initializer only
+```
+
+- Globals may have a constant scalar initializer. Locals are uninitialized.
+- One declaration per statement (no `int a, b;`).
+- Array sizes are integer-constant literals.
+
+## Functions
+
+- Parameters are scalars, pointers, or `struct *` (never struct by value).
+- Recursion supported and required.
+- Forward references allowed.
+- All arguments passed on the stack, right-to-left; result in `a0` (x6).
+
+## Statements
+
+- `expr ;`
+- `return expr ;` / `return ;`
+- `{ ... }` block (scope)
+- `if (expr) stmt` / `if (expr) stmt else stmt`
+- `while (expr) stmt`
+- `break ;` / `continue ;`  — innermost `while` only
+- local declaration (anywhere a statement may appear)
+- `asm("...");` — emit the string verbatim into output assembly (escape hatch)
+
+**Dropped:** `for`, `switch`, `do/while`, `goto`.
+Rewrite `for` as `while`. `switch` is sugar for an `if`/`else if` ladder, which the
+language already expresses (and which the compiler uses for token dispatch); it may
+be added later as pure syntactic sugar without ABI impact.
+
+> **`continue` in `while` (important):** `continue` jumps to the loop's condition
+> test, not past an increment. Unlike `for`, a `while` keeps its increment in the
+> body, so the increment must appear *before* any `continue` that should still
+> advance the loop — otherwise `continue` re-tests an unchanged condition and spins.
+> Idiom: `while (i < n) { i = i + 1; if (skip) continue; ...; }`.
+
+## Expressions
+
+Precedence (low -> high), left-associative except assignment and unary:
+
+1.  assignment `=`
+2.  equality `==` `!=`
+3.  relational `<` `<=` `>` `>=`   (signed or unsigned per operand type)
+4.  bitwise or `|`
+5.  bitwise xor `^`
+6.  bitwise and `&`
+7.  shift `<<` `>>`   (`>>` arithmetic on signed, logical on unsigned)
+8.  additive `+` `-`
+9.  multiplicative `*` `/` `%`
+10. unary `-` `~` `*`(deref) `&`(address-of) `(type)`(cast)
+11. postfix `f(args)` `a[i]` `s.field` `p->field`
+12. primary: identifier, int literal, char literal, string literal, `(expr)`
+
+- **Dropped:** `&&`, `||`, `!`, `?:`, `++`, `--`, compound assignment (`+=` etc.),
+  comma operator. Use nested `if` for `&&`; `x == 0` for `!x`; `x = x + 1` for `x++`.
+- **Casts** limited to integer<->pointer and pointer<->pointer for absolute
+  addresses: `*(volatile char *)0xF000 = c;`  `(struct Dev *)0x9100`. No arithmetic
+  conversions beyond sign reinterpretation.
+- `volatile` accepted in declarations and casts. Because the compiler does no
+  optimization, every access already emits a real load/store, so `volatile` is
+  honored automatically; the keyword is accepted for portability and intent.
+- String literals have type `char *`, stored in a read-only pool.
+- `*` `/` `%` use runtime helpers `__mul` `__div` `__mod`; all other operators are
+  single ZX16 instructions.
+
+## Lexical
+
+- Identifiers: `[A-Za-z_][A-Za-z0-9_]*`
+- Integer literals: decimal and `0x` hex (hex essential for embedded).
+- Char literals: `'a'`, escapes `\n \t \0 \\ \' \r`.
+- String literals: `"..."`, same escapes.
+- Comments: `//` to end of line. (No `/* */`.)
+- No preprocessor. Single source file; use `int`/`unsigned` globals as constants.
+
+## Runtime / ABI (ZX16)
+
+- `int`/`unsigned`/`char`/pointer occupy one 16-bit stack slot when evaluated.
+- Stack-based evaluation: every expression leaves its result in `x6`. A binary op
+  pushes the left operand, evaluates the right into `x6`, pops left into `x5`,
+  combines into `x6`.
+- Calling convention: caller pushes args right-to-left, `call`, then pops args.
+  Result in `a0` (x6). **Every non-leaf function saves/restores `ra` (x1)** — `call`
+  clobbers it.
+- Frame: `push ra; push s0; mv s0, sp; sub sp for locals`. Param i at `s0+4+2i`;
+  local i at `s0-2-2i`. `s0` = x3 = frame pointer.
+- Runtime helpers `__mul/__div/__mod` are **callee-saved for x3/x4**.
+- `crt0` sets `sp = 0xF000`, calls `main`, halts via `ecall 0x3FF`.
+- MMIO: absolute addresses via integer->pointer cast, e.g. `*(volatile char*)0xF000`.
+  Byte access uses `lb`/`lbu`/`sb`; word uses `lw`/`sw`.
+
+## Codegen rules forced by ZX16 (validated against the simulator)
+
+- **Two-operand destructive ALU**: `add rd,rs` => `rd=rd+rs`. Binary ops arrange
+  operands first. `slt`/`and`/`or`/`xor`/`sll`/`srl`/`sra` are all two-operand.
+- **Branch range +-16 bytes**: `if`/`while` use a short conditional branch over an
+  unconditional far jump (`la`+`jr`, unbounded), so bodies of any size work. A direct
+  `j` reaches only +-512 bytes, so codegen never emits one.
+- **Direct jump/call range +-512 bytes**: codegen always calls via `la`+`jalr`, so a
+  function is reachable regardless of distance — required once the program grows large
+  (e.g. the self-hosted compiler).
+- **Load/store offset +-7 bytes**: larger struct/frame/array offsets are computed
+  into a register (`addi` for <=63, `li16`+`add` beyond).
+- Compiler-generated labels use a non-dot prefix (dot-labels are directives).
+
+## What "self-hosting + embedded" requires (checklist)
+
+Compiler needs: recursion, calls, `int`/`char`/pointers/arrays/**structs**, globals,
+string literals, `if/else`, `while`, comparison/arithmetic operators, character-level
+string processing.
+
+Embedded needs: `unsigned`, `char` as true byte, bitwise `& | ^ ~ << >>`,
+integer<->pointer casts for MMIO, `volatile` (auto-honored), `asm()` escape hatch,
+hex literals.
+
+Both sets are present; neither needs anything dropped. The subset is closed.

--- a/simulator/zx16sim.py
+++ b/simulator/zx16sim.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Minimal ZX16 ISA simulator — enough to execute compiler output and validate it.
+
+Implements the ZX16 instruction set per the corrected spec:
+  - 8 GP registers x0..x7, 16-bit, two's complement
+  - PC, byte-addressable 64KB little-endian memory
+  - SP (x2) reset to 0xF000
+  - ECALL services for basic I/O so test programs can print / read / halt
+
+This is a validation tool for the ZC compiler, not a teaching artifact.
+"""
+import sys
+
+MASK = 0xFFFF
+
+def s16(v):
+    v &= MASK
+    return v - 0x10000 if v >= 0x8000 else v
+
+class ZX16:
+    def __init__(self, mem_size=0x10000):
+        self.mem = bytearray(mem_size)
+        self.reg = [0]*8
+        self.pc = 0x0020          # programs start at 0x0020 by convention
+        self.reg[2] = 0xF000      # sp
+        self.halted = False
+        self.out = []             # captured stdout (ints/chars)
+        self.cycles = 0
+        self.max_cycles = 5_000_000
+        # --- MMIO device model (0xF000..0xFFFF) ---
+        self.mmio_base = 0xF000
+        self.mmio_writes = []     # log of (addr, value, size) writes to MMIO
+        self.mmio_regs = {}       # addr -> current value (byte granularity)
+        # scripted reads: addr -> list of values returned on successive reads
+        self.mmio_read_script = {}
+
+    def load(self, data, addr=0x0020):
+        self.mem[addr:addr+len(data)] = data
+
+    def is_mmio(self, a):
+        return a >= self.mmio_base
+
+    def _read_byte(self, a):
+        if self.is_mmio(a):
+            if a in self.mmio_read_script and self.mmio_read_script[a]:
+                return self.mmio_read_script[a].pop(0) & 0xFF
+            return self.mmio_regs.get(a, 0) & 0xFF
+        return self.mem[a]
+
+    def _write_byte(self, a, v):
+        v &= 0xFF
+        if self.is_mmio(a):
+            self.mmio_regs[a] = v
+            self.mmio_writes.append((a, v, 1))
+        else:
+            self.mem[a] = v
+
+    def lw(self, a):
+        return self._read_byte(a) | (self._read_byte((a+1)&MASK) << 8)
+    def sw(self, a, v):
+        if self.is_mmio(a):
+            self.mmio_regs[a] = v & 0xFF
+            self.mmio_regs[(a+1)&MASK] = (v>>8) & 0xFF
+            self.mmio_writes.append((a, v & MASK, 2))
+        else:
+            self.mem[a] = v & 0xFF
+            self.mem[(a+1)&MASK] = (v >> 8) & 0xFF
+    def lb(self, a):
+        return self._read_byte(a)
+
+    def step(self):
+        w = self.lw(self.pc)
+        op = w & 0x7
+        f3 = (w >> 3) & 0x7
+        rd = (w >> 6) & 0x7        # rd/rs1
+        nextpc = (self.pc + 2) & MASK
+
+        if op == 0:  # R-type
+            funct4 = (w >> 12) & 0xF
+            rs2 = (w >> 9) & 0x7
+            a = self.reg[rd]; b = self.reg[rs2]
+            if   funct4 == 0x0: self.reg[rd] = (a + b) & MASK            # ADD
+            elif funct4 == 0x1: self.reg[rd] = (a - b) & MASK            # SUB
+            elif funct4 == 0x2: self.reg[rd] = 1 if s16(a) < s16(b) else 0   # SLT
+            elif funct4 == 0x3: self.reg[rd] = 1 if (a & MASK) < (b & MASK) else 0  # SLTU
+            elif funct4 == 0x4: self.reg[rd] = (a << (b & 0xF)) & MASK   # SLL
+            elif funct4 == 0x5: self.reg[rd] = (a & MASK) >> (b & 0xF)   # SRL
+            elif funct4 == 0x6: self.reg[rd] = (s16(a) >> (b & 0xF)) & MASK  # SRA
+            elif funct4 == 0x7: self.reg[rd] = (a | b) & MASK            # OR
+            elif funct4 == 0x8: self.reg[rd] = (a & b) & MASK            # AND
+            elif funct4 == 0x9: self.reg[rd] = (a ^ b) & MASK            # XOR
+            elif funct4 == 0xA: self.reg[rd] = b                         # MV
+            elif funct4 == 0xB: nextpc = self.reg[rd]                    # JR  PC<-rd
+            elif funct4 == 0xC:                                          # JALR
+                tmp = self.reg[rs2]; self.reg[rd] = nextpc; nextpc = tmp
+            else: raise Exception(f"bad R funct4 {funct4:x} @ {self.pc:04x}")
+
+        elif op == 1:  # I-type
+            imm7 = (w >> 9) & 0x7F
+            simm = imm7 - 0x80 if imm7 >= 0x40 else imm7
+            a = self.reg[rd]
+            if   f3 == 0x0: self.reg[rd] = (a + simm) & MASK            # ADDI
+            elif f3 == 0x1: self.reg[rd] = 1 if s16(a) < simm else 0    # SLTI
+            elif f3 == 0x2: self.reg[rd] = 1 if (a & MASK) < (simm & MASK) else 0  # SLTUI
+            elif f3 == 0x3:                                            # shifts
+                styp = (imm7 >> 4) & 0x7; amt = imm7 & 0xF
+                if   styp == 0x1: self.reg[rd] = (a << amt) & MASK     # SLLI
+                elif styp == 0x2: self.reg[rd] = (a & MASK) >> amt     # SRLI
+                elif styp == 0x4: self.reg[rd] = (s16(a) >> amt) & MASK # SRAI
+                else: raise Exception(f"bad shift type {styp}")
+            elif f3 == 0x4: self.reg[rd] = (a | (imm7 & 0x7F)) & MASK  # ORI (mask low7)
+            elif f3 == 0x5: self.reg[rd] = (a & (simm & MASK)) & MASK  # ANDI (signext)
+            elif f3 == 0x6: self.reg[rd] = (a ^ (simm & MASK)) & MASK  # XORI (signext)
+            elif f3 == 0x7: self.reg[rd] = simm & MASK                 # LI
+            else: raise Exception(f"bad I f3 {f3}")
+
+        elif op == 2:  # B-type
+            imm_hi = (w >> 12) & 0xF
+            rs2 = (w >> 9) & 0x7
+            off5 = (imm_hi << 1)
+            if off5 >= 0x10: off5 -= 0x20      # 5-bit signed, imm[0]=0
+            a = self.reg[rd]; b = self.reg[rs2]
+            take = False
+            if   f3 == 0x0: take = (a == b)
+            elif f3 == 0x1: take = (a != b)
+            elif f3 == 0x2: take = (a == 0)
+            elif f3 == 0x3: take = (a != 0)
+            elif f3 == 0x4: take = (s16(a) <  s16(b))
+            elif f3 == 0x5: take = (s16(a) >= s16(b))
+            elif f3 == 0x6: take = ((a&MASK) <  (b&MASK))
+            elif f3 == 0x7: take = ((a&MASK) >= (b&MASK))
+            if take: nextpc = (nextpc + off5) & MASK
+
+        elif op == 3:  # S-type  store
+            imm4 = (w >> 12) & 0xF
+            rs2 = (w >> 9) & 0x7
+            off = imm4 - 0x10 if imm4 >= 0x8 else imm4
+            addr = (self.reg[rd] + off) & MASK
+            if   f3 == 0x0: self._write_byte(addr, self.reg[rs2])       # SB
+            elif f3 == 0x1: self.sw(addr, self.reg[rs2])               # SW
+            else: raise Exception("bad S f3")
+
+        elif op == 4:  # L-type  load
+            imm4 = (w >> 12) & 0xF
+            rs2 = (w >> 9) & 0x7        # base
+            off = imm4 - 0x10 if imm4 >= 0x8 else imm4
+            addr = (self.reg[rs2] + off) & MASK
+            if   f3 == 0x0:                                            # LB signed
+                v = self._read_byte(addr); self.reg[rd] = (v - 0x100 if v >= 0x80 else v) & MASK
+            elif f3 == 0x1: self.reg[rd] = self.lw(addr)               # LW
+            elif f3 == 0x4: self.reg[rd] = self._read_byte(addr)      # LBU
+            else: raise Exception("bad L f3")
+
+        elif op == 5:  # J-type, PC-relative to PC+2
+            link = (w >> 15) & 0x1
+            imm_hi = (w >> 9) & 0x3F     # imm[9:4]
+            imm_lo = (w >> 3) & 0x7      # imm[3:1]
+            off = (imm_hi << 4) | (imm_lo << 1)   # imm[9:1] with imm[0]=0
+            if off >= 0x200: off -= 0x400          # 10-bit signed (sign bit = bit 9)
+            if link: self.reg[rd] = nextpc
+            nextpc = (nextpc + off) & MASK
+
+        elif op == 6:  # U-type
+            flag = (w >> 15) & 0x1
+            imm_hi = (w >> 9) & 0x3F
+            imm_lo = (w >> 3) & 0x7
+            v9 = (imm_hi << 3) | imm_lo
+            val = (v9 << 7) & MASK
+            if flag == 0: self.reg[rd] = val                 # LUI
+            else: self.reg[rd] = (self.pc + val) & MASK       # AUIPC
+
+        elif op == 7:  # SYS  ECALL
+            svc = (w >> 6) & 0x3FF
+            self.ecall(svc)
+
+        self.pc = nextpc
+        self.cycles += 1
+
+    def ecall(self, svc):
+        # Minimal service set for validation:
+        #  0x000 print int in a0 (x6)
+        #  0x001 print char in a0
+        #  0x3FF halt
+        if svc == 0x3FF:
+            self.halted = True
+        elif svc == 0x000:
+            self.out.append(('int', s16(self.reg[6])))
+        elif svc == 0x001:
+            self.out.append(('char', self.reg[6] & 0xFF))
+        else:
+            # unknown service: ignore
+            pass
+
+    def run(self):
+        while not self.halted:
+            self.step()
+            if self.cycles > self.max_cycles:
+                raise Exception("cycle limit exceeded (infinite loop?)")
+        return self.out
+
+
+def assemble_and_run(asm_text, asm_path=None, pre_run=None):
+    """Helper: assemble ZX16 source via the repo assembler, then execute.
+    pre_run(sim) is called after load, before run() — used to script MMIO reads.
+    asm_path defaults to ../assembler/zx16asm.py relative to this file."""
+    import subprocess, tempfile, os
+    if asm_path is None:
+        asm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', 'assembler', 'zx16asm.py')
+    with tempfile.NamedTemporaryFile('w', suffix='.s', delete=False) as f:
+        f.write(asm_text); src = f.name
+    out_bin = src + '.bin'
+    r = subprocess.run([sys.executable, asm_path, src, '-o', out_bin],
+                       capture_output=True, text=True)
+    if 'successfully' not in r.stdout:
+        raise Exception("assembly failed:\n" + r.stdout + r.stderr)
+    data = open(out_bin, 'rb').read()
+    sim = ZX16()
+    # assembler emits a full 64KB image with sections already at absolute addrs
+    sim.load(data, 0x0000)
+    if pre_run: pre_run(sim)
+    return sim.run(), sim
+
+
+if __name__ == '__main__':
+    # self-check against known multiply program (7*6 = 42)
+    prog = """
+.text
+.org 0x0020
+main:
+    li   x6, 6
+    push x6
+    li   x6, 7
+    push x6
+    call __mul
+    addi x2, 4
+    ecall 0x000
+    ecall 0x3FF
+__mul:
+    lw   x3, 0(x2)
+    lw   x4, 2(x2)
+    li   x6, 0
+mul_loop:
+    bz   x3, mul_done
+    add  x6, x4
+    addi x3, -1
+    j    mul_loop
+mul_done:
+    ret
+"""
+    out, sim = assemble_and_run(prog)
+    print("output:", out)
+    assert out == [('int', 42)], out
+    print("simulator self-check PASSED (7*6=42)")


### PR DESCRIPTION
Assembler (assembler/zx16asm.py):
- ORI/ANDI/XORI accept the full 7-bit immediate field (0..127)
- Correct pseudo-instruction sizing: li16/la/push/pop/neg are 4 bytes, so labels following them are placed at the right address
- Tighten the J-type jump range check to the true encodable range -512..+510 (offset is imm[9:1], sign bit 9). The previous -1024..+1020 check silently miscompiled 511 out-of-range offsets (e.g. +800 assembled and then executed as -224).

New:
- simulator/zx16sim.py: ZX16 ISA simulator with an MMIO device model
- compiler/: ZC (a self-hosting C subset) -> ZX16 assembly toolchain -- lexer/parser (zcc.py), codegen (codegen.py), the validated pattern library (codegen_patterns.py), example programs, and three test suites
- docs/README_corrected.md: corrected ISA spec (LI16 = LUI+ORI not LUI+ADDI, fixed NEG/NOP, x0 is general-purpose, J-range -512..+510)
- docs/SPEC.md: the ZC language specification
- MANIFEST.md: repository index

Verified by execution: codegen patterns 11/11, end-to-end compile 12/12, embedded examples 6/6 (incl. a TEA cipher checked against a reference), and the simulator self-check.