### PR TITLE
Add single-cycle ZX16 CPU (RTL, Verilog-2001)

### DIFF
--- a/rtl/README.md
+++ b/rtl/README.md
@@ -1,0 +1,50 @@
+# ZX16 single-cycle CPU (RTL)
+
+A single-cycle implementation of the ZX16 ISA in **Verilog-2001**, verified against the
+Python golden simulator (`simulator/zx16sim.py`) on every example program.
+
+## Files
+| File | Role |
+|------|------|
+| `zx16_core.v` | datapath + control + register file (one instruction per clock) |
+| `zx16_alu.v`  | 16-bit ALU |
+| `zx16_mem.v`  | unified 64 KB memory, word-organized, async read / sync write |
+| `zx16_top.v`  | core + memory + a minimal scripted MMIO device (for `02_poll_status`) |
+| `tb_zx16.v`   | testbench: `$readmemh` a program image, emulate ECALL print/halt |
+| `verify.py`   | differential test: every example through the RTL **and** the golden sim |
+
+## Verify
+```sh
+python3 rtl/verify.py
+```
+Compiles the RTL with iverilog, assembles each of the 9 ZC examples to a `$readmemh`
+image, runs them on both the core and `zx16sim.py`, and diffs the console output.
+Expected: `9/9 examples: RTL output matches the golden simulator` (includes MD5 and an
+8-point FFT).
+
+Structural check (no latches / loops / multiple drivers):
+```sh
+yosys -p "read_verilog rtl/zx16_alu.v rtl/zx16_mem.v rtl/zx16_core.v rtl/zx16_top.v; \
+          hierarchy -top zx16_top; proc; check -assert"
+```
+
+## Design notes
+- **Single-cycle**: combinational fetch/decode/execute; PC, registers, and memory
+  commit on the rising edge. Memory is **async-read** — a simulation/teaching model;
+  an FPGA mapping would use synchronous BRAM (and a multi-cycle or pipelined front end).
+- **ECALL = halt + debug ports**: `ecall_svc` and `dbg_a0` are exposed; svc `0x3FF`
+  halts, `0x000`/`0x001` are the print services the testbench performs (mirrors the sim).
+- **Reset**: PC = `0x0020` (the toolchain's program-entry convention; architectural
+  reset is `0x0000`, where a boot vector would live). SP (x2) = `0xF000`.
+- **ISA specifics encoded** (several were spec bugs fixed earlier in this project):
+  the two-operand `rd/rs1 = [8:6]` field sharing; `x0` is a normal register (not
+  hardwired zero); `ORI` zero-extends its imm7 while the other I-type immediates
+  sign-extend; branches and `J`/`JAL` are PC+2-relative, `AUIPC` is PC-relative, and
+  `JR`/`JALR` are absolute; the `J`/`JAL` range is ±512.
+
+## Status & limitations
+- 9/9 examples match the golden simulator; yosys structural check clean.
+- One block of execution, **no interrupts/traps** yet (ECALL only halts/prints).
+- The software `__mul`/`__div` runtime is O(operand), so programs with negative or
+  large multiplicands (e.g. the FFT's negative twiddles) execute millions of
+  instructions — correct, but slow; the testbench cycle cap is sized accordingly.

--- a/rtl/tb_zx16.v
+++ b/rtl/tb_zx16.v
@@ -1,0 +1,43 @@
+// tb_zx16.v -- testbench: load a $readmemh image (+mem=<file>), run the core,
+// emulate ECALL services (print int / char, halt), and stop. Samples on negedge
+// so the combinational ecall_valid/dbg_a0 reflect the instruction executing this
+// cycle (before the rising edge advances PC). Output lines are machine-parseable
+// for the differential harness (rtl/verify.py):
+//   "OUT INT <signed-decimal>"   "OUT CHR <0..255>"   "OUT HALT"
+module tb_zx16;
+    reg clk = 1'b0;
+    reg rst = 1'b1;
+    wire        halt, ecall_valid;
+    wire [9:0]  ecall_svc;
+    wire [15:0] dbg_a0;
+
+    zx16_top dut(.clk(clk), .rst(rst), .halt(halt),
+                 .ecall_valid(ecall_valid), .ecall_svc(ecall_svc), .dbg_a0(dbg_a0));
+
+    always #5 clk = ~clk;
+
+    reg [1023:0] memfile;
+    integer cyc;
+    initial begin
+        if (!$value$plusargs("mem=%s", memfile)) begin
+            $display("ERROR: no +mem=<file>"); $finish;
+        end
+        $readmemh(memfile, dut.mem.mem);
+        @(posedge clk);          // apply reset
+        @(negedge clk); rst = 1'b0;
+        // generous cap: the software __mul/__div are O(operand), so programs with
+        // negative/large multiplicands (e.g. the FFT's negative twiddles) can run
+        // into the millions of instructions. Halts early via ECALL 0x3FF.
+        for (cyc = 0; cyc < 20000000; cyc = cyc + 1) begin
+            @(negedge clk);
+            if (ecall_valid) begin
+                if      (ecall_svc == 10'h000) $display("OUT INT %0d", $signed(dbg_a0));
+                else if (ecall_svc == 10'h001) $display("OUT CHR %0d", dbg_a0[7:0]);
+                else if (ecall_svc == 10'h3FF) begin
+                    $display("OUT HALT"); $finish;
+                end
+            end
+        end
+        $display("OUT TIMEOUT"); $finish;
+    end
+endmodule

--- a/rtl/verify.py
+++ b/rtl/verify.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Differential verification for the ZX16 single-cycle RTL core.
+
+For each ZC example: compile it, run it on (a) the Verilog core via iverilog/vvp
+and (b) the Python golden simulator, then compare the console output (the ECALL
+print_int / print_char sequence). A match on every program -- including MD5, FFT,
+and TEA -- is strong evidence the RTL implements the ISA correctly.
+
+Run:  python3 rtl/verify.py
+"""
+import sys, os, glob, subprocess, re, tempfile
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+for d in ('compiler', 'simulator', 'assembler'):
+    sys.path.insert(0, os.path.join(ROOT, d))
+import codegen          # noqa: E402
+import zx16sim as Z     # noqa: E402
+import zx16asm          # noqa: E402
+
+EXAMPLES = os.path.join(ROOT, 'compiler', 'examples')
+RTL_SRCS = ['zx16_alu.v', 'zx16_mem.v', 'zx16_core.v', 'zx16_top.v', 'tb_zx16.v']
+
+
+def build_rtl():
+    vvp = os.path.join(tempfile.gettempdir(), 'zx16_verify.vvp')
+    srcs = [os.path.join(HERE, f) for f in RTL_SRCS]
+    subprocess.run(['iverilog', '-o', vvp] + srcs, check=True)
+    return vvp
+
+
+def sim_output(asm, pre=None):
+    out, _ = Z.assemble_and_run(asm, pre_run=pre)
+    return [('INT' if k == 'int' else 'CHR', v) for k, v in out]
+
+
+def mem_image(asm):
+    a = zx16asm.ZX16Assembler()
+    if not a.assemble(asm, '<verify>'):
+        raise RuntimeError('assembly failed')
+    lines = [L for L in a.get_memory_file_output().splitlines() if not L.startswith('#')]
+    fd, path = tempfile.mkstemp(suffix='.mem')
+    with os.fdopen(fd, 'w') as f:
+        f.write("\n".join(lines) + "\n")
+    return path
+
+
+def rtl_output(vvp, memfile):
+    r = subprocess.run(['vvp', vvp, '+mem=' + memfile],
+                       capture_output=True, text=True, timeout=300)
+    res = []
+    for line in r.stdout.splitlines():
+        m = re.match(r'OUT INT (-?\d+)', line)
+        if m:
+            res.append(('INT', int(m.group(1)))); continue
+        m = re.match(r'OUT CHR (\d+)', line)
+        if m:
+            res.append(('CHR', int(m.group(1)))); continue
+        if 'OUT TIMEOUT' in line:
+            res.append(('TIMEOUT', 0))
+    return res
+
+
+def setup_poll(sim):                       # mirrors test_embedded's 02 setup
+    sim.mmio_read_script[0xF020] = [0, 0, 1]
+    sim.mmio_regs[0xF021] = 99
+
+
+def main():
+    vvp = build_rtl()
+    progs = sorted(glob.glob(os.path.join(EXAMPLES, '*.c')))
+    npass = 0
+    for c in progs:
+        name = os.path.basename(c)
+        asm = codegen.compile_src(open(c).read())
+        pre = setup_poll if name.startswith('02') else None
+        want = sim_output(asm, pre)
+        got = rtl_output(vvp, mem_image(asm))
+        ok = (got == want)
+        npass += ok
+        print(f"{'PASS' if ok else 'FAIL'}  {name:<20} sim={len(want)} vals, rtl={len(got)} vals")
+        if not ok:
+            print(f"      sim: {want}")
+            print(f"      rtl: {got}")
+    print(f"\n{npass}/{len(progs)} examples: RTL output matches the golden simulator")
+    sys.exit(0 if npass == len(progs) else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/rtl/zx16_alu.v
+++ b/rtl/zx16_alu.v
@@ -1,0 +1,29 @@
+// zx16_alu.v -- ZX16 16-bit ALU (combinational). Verilog-2001.
+// op codes are shared with the core (see localparams below; keep in sync).
+module zx16_alu(
+    input      [3:0]  op,
+    input      [15:0] a,
+    input      [15:0] b,
+    input      [3:0]  shamt,   // shift amount 0..15
+    output reg [15:0] y
+);
+    localparam ALU_ADD=4'd0, ALU_SUB=4'd1, ALU_SLT=4'd2, ALU_SLTU=4'd3,
+               ALU_SLL=4'd4, ALU_SRL=4'd5, ALU_SRA=4'd6, ALU_OR=4'd7,
+               ALU_AND=4'd8, ALU_XOR=4'd9, ALU_PASSB=4'd10;
+    always @(*) begin
+        case (op)
+            ALU_ADD : y = a + b;
+            ALU_SUB : y = a - b;
+            ALU_SLT : y = ($signed(a) <  $signed(b)) ? 16'd1 : 16'd0;
+            ALU_SLTU: y = (a < b)                      ? 16'd1 : 16'd0;
+            ALU_SLL : y = a << shamt;
+            ALU_SRL : y = a >> shamt;
+            ALU_SRA : y = $signed(a) >>> shamt;
+            ALU_OR  : y = a | b;
+            ALU_AND : y = a & b;
+            ALU_XOR : y = a ^ b;
+            ALU_PASSB: y = b;
+            default : y = 16'd0;
+        endcase
+    end
+endmodule

--- a/rtl/zx16_core.v
+++ b/rtl/zx16_core.v
@@ -1,0 +1,189 @@
+// zx16_core.v -- ZX16 single-cycle CPU core (Verilog-2001).
+// One instruction per clock. Combinational fetch/decode/execute; PC, register
+// file, and memory writes commit on the rising edge.
+//
+// ZX16 specifics encoded here (several were spec bugs fixed earlier this project):
+//   * Two-operand ALU: rd/rs1 share field [8:6]. rs2 = [11:9].
+//   * x0 is a NORMAL register (not hardwired zero).
+//   * ORI zero-extends its imm7; all other I-type immediates sign-extend.
+//   * Branches and J/JAL are PC+2-relative; AUIPC adds to the instruction's PC;
+//     JR/JALR are absolute (register). JR target = reg[8:6]; JALR target = reg[11:9],
+//     link -> reg[8:6].
+//   * J/JAL offset = sext({imm[9:4],imm[3:1],0})  (range -512..+510).
+//   * LUI/AUIPC immediate = imm9 << 7.
+//   * Reset: PC = RESET_PC (0x0020, the toolchain entry convention), SP(x2)=0xF000.
+//   * ECALL: svc 0x3FF halts; svc/a0 are exposed for the environment to print.
+module zx16_core #(
+    parameter RESET_PC = 16'h0020
+)(
+    input             clk,
+    input             rst,
+    // instruction memory (async read)
+    output     [15:0] iaddr,
+    input      [15:0] idata,
+    // data memory
+    output     [15:0] daddr,
+    input      [15:0] drdata,   // word read
+    input      [7:0]  drbyte,   // byte read
+    output            dwe,       // data write enable
+    output            dword,     // 1 = word store, 0 = byte store
+    output     [15:0] dwdata,
+    output            dre,       // data read enable (load)
+    // ecall / debug
+    output            ecall_valid,
+    output     [9:0]  ecall_svc,
+    output     [15:0] dbg_a0,
+    output            halted
+);
+    // ---- ALU op encoding (must match zx16_alu.v) ----
+    localparam ALU_ADD=4'd0, ALU_SUB=4'd1, ALU_SLT=4'd2, ALU_SLTU=4'd3,
+               ALU_SLL=4'd4, ALU_SRL=4'd5, ALU_SRA=4'd6, ALU_OR=4'd7,
+               ALU_AND=4'd8, ALU_XOR=4'd9, ALU_PASSB=4'd10;
+    // ---- opcodes ----
+    localparam OP_R=3'b000, OP_I=3'b001, OP_B=3'b010, OP_S=3'b011,
+               OP_L=3'b100, OP_J=3'b101, OP_U=3'b110, OP_SYS=3'b111;
+
+    reg [15:0] pc;
+    reg        halt_r;
+    reg [15:0] regs [0:7];
+
+    wire [15:0] inst   = idata;
+    wire [2:0]  opcode = inst[2:0];
+    wire [2:0]  func3  = inst[5:3];
+    wire [2:0]  a_field= inst[8:6];   // rd / rs1
+    wire [2:0]  b_field= inst[11:9];  // rs2
+    wire [3:0]  funct4 = inst[15:12];
+    wire [6:0]  imm7   = inst[15:9];
+    wire [9:0]  svc    = inst[15:6];
+
+    assign iaddr  = pc;
+    assign dbg_a0 = regs[6];
+    assign halted = halt_r;
+
+    // ---- register reads ----
+    wire [15:0] ra = regs[a_field];   // src1 / S-base / JR-target
+    wire [15:0] rb = regs[b_field];   // src2 / L-base / JALR-target / S-data
+
+    // ---- immediates ----
+    wire [15:0] imm_i_s = {{9{imm7[6]}}, imm7};                 // sign-extended imm7
+    wire [15:0] imm_i_z = {9'b0, imm7};                         // zero-extended (ORI)
+    wire [15:0] imm_i   = (opcode==OP_I && func3==3'd4) ? imm_i_z : imm_i_s;
+    wire [15:0] imm_ls  = {{12{inst[15]}}, inst[15:12]};        // 4-bit signed (L/S)
+    wire [15:0] off_b   = {{11{inst[15]}}, inst[15:12], 1'b0};  // 5-bit signed branch
+    wire [15:0] off_j   = {{6{inst[14]}}, inst[14:9], inst[5:3], 1'b0}; // 10-bit signed jump
+    wire [15:0] uimm    = {inst[14:9], inst[5:3], 7'b0};        // imm9 << 7
+
+    // ---- ALU control ----
+    reg [3:0] alu_op;
+    always @(*) begin
+        if (opcode==OP_R) begin
+            case (funct4)
+                4'h0: alu_op=ALU_ADD;  4'h1: alu_op=ALU_SUB;  4'h2: alu_op=ALU_SLT;
+                4'h3: alu_op=ALU_SLTU; 4'h4: alu_op=ALU_SLL;  4'h5: alu_op=ALU_SRL;
+                4'h6: alu_op=ALU_SRA;  4'h7: alu_op=ALU_OR;   4'h8: alu_op=ALU_AND;
+                4'h9: alu_op=ALU_XOR;  4'hA: alu_op=ALU_PASSB; default: alu_op=ALU_ADD;
+            endcase
+        end else begin // I-type (and don't-cares for other formats)
+            case (func3)
+                3'd0: alu_op=ALU_ADD;  3'd1: alu_op=ALU_SLT;  3'd2: alu_op=ALU_SLTU;
+                3'd4: alu_op=ALU_OR;   3'd5: alu_op=ALU_AND;  3'd6: alu_op=ALU_XOR;
+                3'd7: alu_op=ALU_PASSB;
+                3'd3: case (imm7[6:4])
+                        3'b001: alu_op=ALU_SLL; 3'b010: alu_op=ALU_SRL;
+                        3'b100: alu_op=ALU_SRA; default: alu_op=ALU_SLL;
+                      endcase
+                default: alu_op=ALU_ADD;
+            endcase
+        end
+    end
+
+    wire [15:0] alu_a = ra;
+    wire [15:0] alu_b = (opcode==OP_I) ? imm_i : rb;
+    wire [3:0]  shamt = (opcode==OP_I) ? inst[12:9] : rb[3:0]; // I: imm[3:0]; R: rs2[3:0]
+    wire [15:0] alu_y;
+    zx16_alu u_alu(.op(alu_op), .a(alu_a), .b(alu_b), .shamt(shamt), .y(alu_y));
+
+    // ---- instruction class helpers ----
+    wire is_load  = (opcode==OP_L);
+    wire is_store = (opcode==OP_S);
+    wire is_jr    = (opcode==OP_R) && (funct4==4'hB);
+    wire is_jalr  = (opcode==OP_R) && (funct4==4'hC);
+    wire is_jal   = (opcode==OP_J) && inst[15];        // link=1
+    wire is_lui   = (opcode==OP_U) && (inst[15]==1'b0);
+    wire is_auipc = (opcode==OP_U) && (inst[15]==1'b1);
+    wire [15:0] pc_plus2 = pc + 16'd2;
+
+    // ---- data memory interface ----
+    assign daddr  = is_store ? (ra + imm_ls) : (rb + imm_ls); // S base=rs1, L base=rs2
+    assign dwdata = rb;                                        // S data = rs2
+    assign dword  = (func3==3'd1);                             // SW
+    assign dwe    = is_store && ~halt_r && ~rst;
+    assign dre    = is_load  && ~halt_r;
+
+    // load result (LW word / LB signed byte / LBU zero byte)
+    wire [15:0] load_data = (func3==3'd1) ? drdata :
+                            (func3==3'd0) ? {{8{drbyte[7]}}, drbyte} : // LB
+                                            {8'b0, drbyte};            // LBU
+
+    // ---- writeback mux ----
+    wire [15:0] wb_data =
+        is_load            ? load_data        :
+        (is_jal||is_jalr)  ? pc_plus2         :  // link = PC+2
+        is_lui             ? uimm             :
+        is_auipc           ? (pc + uimm)      :
+                             alu_y;
+
+    wire wr_en =
+        (opcode==OP_I) ? 1'b1 :
+        (opcode==OP_L) ? 1'b1 :
+        (opcode==OP_U) ? 1'b1 :
+        (opcode==OP_J) ? inst[15] :          // JAL writes, J does not
+        (opcode==OP_R) ? (funct4 != 4'hB) :  // all R write except JR
+                         1'b0;               // B / S / SYS
+    wire [2:0] wr_addr = a_field;            // every writing op targets [8:6]
+
+    // ---- branch condition ----
+    wire sgn_lt = ($signed(ra) < $signed(rb));
+    wire usn_lt = (ra < rb);
+    reg  branch_taken;
+    always @(*) begin
+        case (func3)
+            3'd0: branch_taken = (ra==rb);     // BEQ
+            3'd1: branch_taken = (ra!=rb);     // BNE
+            3'd2: branch_taken = (ra==16'd0);  // BZ  (rs1)
+            3'd3: branch_taken = (ra!=16'd0);  // BNZ
+            3'd4: branch_taken = sgn_lt;       // BLT
+            3'd5: branch_taken = ~sgn_lt;      // BGE
+            3'd6: branch_taken = usn_lt;       // BLTU
+            3'd7: branch_taken = ~usn_lt;      // BGEU
+            default: branch_taken = 1'b0;
+        endcase
+    end
+
+    // ---- next PC ----
+    wire [15:0] next_pc =
+        (opcode==OP_B && branch_taken) ? (pc_plus2 + off_b) :
+        (opcode==OP_J)                 ? (pc_plus2 + off_j) :
+        is_jr                          ? ra :   // JR  : PC <- reg[8:6]
+        is_jalr                        ? rb :   // JALR: PC <- reg[11:9]
+                                         pc_plus2;
+
+    // ---- ecall ----
+    assign ecall_valid = (opcode==OP_SYS) && ~halt_r;
+    assign ecall_svc   = svc;
+
+    // ---- sequential state ----
+    integer i;
+    always @(posedge clk) begin
+        if (rst) begin
+            pc     <= RESET_PC;
+            halt_r <= 1'b0;
+            for (i=0;i<8;i=i+1) regs[i] <= 16'd0;
+            regs[2] <= 16'hF000;          // SP
+        end else if (!halt_r) begin
+            pc <= next_pc;
+            if (wr_en) regs[wr_addr] <= wb_data;
+            if (opcode==OP_SYS && svc==10'h3FF) halt_r <= 1'b1;
+        end
+    end
+endmodule

--- a/rtl/zx16_mem.v
+++ b/rtl/zx16_mem.v
@@ -1,0 +1,29 @@
+// zx16_mem.v -- unified 64KB memory, word-organized (matches the assembler's
+// `-f mem` image: 32768 little-endian 16-bit words, word index = byte_addr/2).
+// Asynchronous (combinational) reads on two ports (fetch + data) make the core
+// truly single-cycle; writes are synchronous. Word accesses must be even-aligned
+// (the ISA requires it); byte accesses select the high/low byte of a word.
+// NOTE: async-read RAM is a simulation/teaching model; FPGA BRAM would differ.
+module zx16_mem(
+    input             clk,
+    input      [15:0] iaddr,    // instruction fetch (byte addr, even)
+    output     [15:0] idata,
+    input      [15:0] daddr,    // data access (byte addr)
+    output     [15:0] drdata,   // word read
+    output     [7:0]  drbyte,   // addressed byte
+    input             mem_we,
+    input             mem_word, // 1 = word store (SW), 0 = byte store (SB)
+    input      [15:0] dwdata
+);
+    reg [15:0] mem [0:32767];
+    assign idata  = mem[iaddr[15:1]];
+    assign drdata = mem[daddr[15:1]];
+    assign drbyte = daddr[0] ? mem[daddr[15:1]][15:8] : mem[daddr[15:1]][7:0];
+    always @(posedge clk) begin
+        if (mem_we) begin
+            if (mem_word)      mem[daddr[15:1]]       <= dwdata;
+            else if (daddr[0]) mem[daddr[15:1]][15:8] <= dwdata[7:0];
+            else               mem[daddr[15:1]][7:0]  <= dwdata[7:0];
+        end
+    end
+endmodule

--- a/rtl/zx16_top.v
+++ b/rtl/zx16_top.v
@@ -1,0 +1,50 @@
+// zx16_top.v -- core + unified memory + a minimal MMIO device model.
+// The device mirrors the Python sim's scripted MMIO for 02_poll_status:
+//   0xF020 STATUS: returns 0 for the first two reads, then bit0=1 (READY)
+//   0xF021 DATA  : returns 99
+// All other addresses (incl. other MMIO like 0xF010/0xF030) are plain RAM, so
+// read-modify-write peripherals (GPIO, timer reg-map) behave as the sim expects.
+module zx16_top #(
+    parameter RESET_PC = 16'h0020
+)(
+    input         clk,
+    input         rst,
+    output        halt,
+    output        ecall_valid,
+    output [9:0]  ecall_svc,
+    output [15:0] dbg_a0
+);
+    wire [15:0] iaddr, idata, daddr, drdata_mem, dwdata;
+    wire [7:0]  drbyte_mem;
+    wire        dwe, dword, dre;
+
+    // ---- scripted STATUS/DATA device for 02_poll_status ----
+    reg  [3:0]  status_reads;
+    wire        sel_status = (daddr == 16'hF020);
+    wire        sel_data   = (daddr == 16'hF021);
+    wire [15:0] status_val = (status_reads >= 4'd2) ? 16'd1 : 16'd0;
+    wire [15:0] drdata = sel_status ? status_val :
+                         sel_data   ? 16'd99      : drdata_mem;
+    wire [7:0]  drbyte = sel_status ? status_val[7:0] :
+                         sel_data   ? 8'd99          : drbyte_mem;
+    always @(posedge clk) begin
+        if (rst)                     status_reads <= 4'd0;
+        else if (dre && sel_status)  status_reads <= status_reads + 4'd1;
+    end
+
+    zx16_core #(.RESET_PC(RESET_PC)) core(
+        .clk(clk), .rst(rst),
+        .iaddr(iaddr), .idata(idata),
+        .daddr(daddr), .drdata(drdata), .drbyte(drbyte),
+        .dwe(dwe), .dword(dword), .dwdata(dwdata), .dre(dre),
+        .ecall_valid(ecall_valid), .ecall_svc(ecall_svc),
+        .dbg_a0(dbg_a0), .halted(halt)
+    );
+
+    zx16_mem mem(
+        .clk(clk),
+        .iaddr(iaddr), .idata(idata),
+        .daddr(daddr), .drdata(drdata_mem), .drbyte(drbyte_mem),
+        .mem_we(dwe), .mem_word(dword), .dwdata(dwdata)
+    );
+endmodule


### PR DESCRIPTION
A single-cycle implementation of the ZX16 ISA, verified against the Python golden simulator on every example program.

- rtl/zx16_core.v: datapath + control + register file (1 instruction/clock)
- rtl/zx16_alu.v; rtl/zx16_mem.v (unified 64KB, async-read); rtl/zx16_top.v
- rtl/tb_zx16.v: $readmemh testbench, ECALL print/halt
- rtl/verify.py: differential test vs simulator/zx16sim.py -- 9/9 match, including MD5 and an 8-point FFT

ECALL is modeled as halt + debug ports; reset PC=0x0020 (entry convention), SP=0xF000. yosys structural check is clean (no latches/loops).